### PR TITLE
docs: corrige formatacao da pagina de requisitos

### DIFF
--- a/docs/Elaboracao/das.md
+++ b/docs/Elaboracao/das.md
@@ -1,19 +1,16 @@
-#  🌸 Documento de Arquitetura de Software (DAS) —  **Sistema de Gestão e Mediação de Estágios Obrigatórios  - IBMEC RJ** 🌸
+# 🌸 Documento de Arquitetura de Software (DAS) — **Sistema de Gestão e Mediação de Estágios Obrigatórios - IBMEC RJ** 🌸
 
 ## 🎀 Introdução
 
 ### 💕 Proposta
 
-<p align = "justify">
 Este documento tem como objetivo consolidar a elicitação inicial de requisitos do sistema, alinhando problema, escopo, funcionalidades, regras de negócio, restrições e requisitos não funcionais que deverão orientar análise, modelagem, desenvolvimento e validação.
-</p>
 
 ### 💕 Escopo
 
-<p align = "justify">
 O sistema deverá cobrir:
 
-- Cadastro e autenticação dos atores (Aluno,Empresa e coordenadores/professores) do processo;
+- Cadastro e autenticação dos atores (Aluno, Empresa e coordenadores/professores) do processo;
 - Abertura de solicitação de estágio obrigatório;
 - Submissão, armazenamento e versionamento de documentos;
 - Geração ou registro do TCE e documentos correlatos;
@@ -24,97 +21,92 @@ O sistema deverá cobrir:
 - Notificações e histórico do processo;
 - Status em tempo real do processo;
 - Relatórios operacionais e gerenciais.
-</p>
 
 ### 💕 Visão Geral
 
-<p align = "justify">
 O projeto propõe uma plataforma web para centralizar a formalização, validação e acompanhamento dos estágios obrigatórios do IBMEC, conectando aluno, empresa concedente, coordenação/secretaria e professor orientador em um fluxo único, com rastreabilidade documental, regras acadêmicas por curso e menor dependência de processos manuais. A proposta técnica atual do projeto considera back-end em Django, banco relacional e uma API com motor de regras para validar exigências acadêmicas e operacionais.
 
-Pela base normativa usada pelo grupo, o estágio deve ser tratado como ****ato educativo supervisionado****, não apenas como vínculo administrativo. Isso impacta diretamente o sistema: a solução precisa considerar matrícula e frequência regulares, compatibilidade entre estágio e formação acadêmica, professor orientador, supervisor da concedente, documentação obrigatória, jornada compatível com aulas, acompanhamento institucional e controle da carga horária validada para integralização curricular. 
+Pela base normativa usada pelo grupo, o estágio deve ser tratado como **ato educativo supervisionado**, não apenas como vínculo administrativo. Isso impacta diretamente o sistema: a solução precisa considerar matrícula e frequência regulares, compatibilidade entre estágio e formação acadêmica, professor orientador, supervisor da concedente, documentação obrigatória, jornada compatível com aulas, acompanhamento institucional e controle da carga horária validada para integralização curricular.
 
 ## 🎀 Representação Arquitetural
 
 ### 💕 Cliente-Servidor
-<p align = "justify"> O sistema utiliza o modelo Cliente-Servidor, onde o processamento é distribuído entre o fornecedor de um serviço (servidor) e o requerente do serviço (cliente). No contexto deste projeto, o servidor centraliza as regras de negócio acadêmicas e a persistência de dados, enquanto o cliente provê a interface para os diferentes perfis de usuários (Aluno, Empresa, Orientador e Coordenação). </p>
 
-**Cliente :**
+O sistema utiliza o modelo Cliente-Servidor, onde o processamento é distribuído entre o fornecedor de um serviço (servidor) e o requerente do serviço (cliente). No contexto deste projeto, o servidor centraliza as regras de negócio acadêmicas e a persistência de dados, enquanto o cliente provê a interface para os diferentes perfis de usuários (Aluno, Empresa, Orientador e Coordenação).
 
--   **View :**  Interface desenvolvida para permitir que o  **Aluno**  inicie solicitações, envie documentos e tenha acesso ao status em tempo real, a  **Empresa**  envie documentos e a  **Coordenação**  realize validações. A interface é responsável por coletar os inputs (como o upload de documentos do  **RF05**) e exibir o status do workflow (conforme o  **RF09**).
+**Cliente:**
+
+- **View:** Interface desenvolvida para permitir que o **Aluno** inicie solicitações, envie documentos e tenha acesso ao status em tempo real, a **Empresa** envie documentos e a **Coordenação** realize validações. A interface é responsável por coletar os inputs (como o upload de documentos do **RF05**) e exibir o status do workflow (conforme o **RF09**).
     
-**Servidor :**
+**Servidor:**
 
--   **Controller :**  Atua como o ponto de entrada das requisições da API. Ele recebe as solicitações do frontend, gerencia a autenticação baseada em perfis (**RNF01**) e direciona as chamadas para os serviços corretos, retornando as respostas em formato compatível com a integração.
+- **Controller:** Atua como o ponto de entrada das requisições da API. Ele recebe as solicitações do frontend, gerencia a autenticação baseada em perfis (**RNF01**) e direciona as chamadas para os serviços corretos, retornando as respostas em formato compatível com a integração.
 
--   **Service :**  Camada onde reside o  **Motor de Regras**  mencionado na visão geral do projeto. É responsável pela lógica de negócio complexa, como validar se a jornada é compatível com as aulas, verificar se o aluno está apto para o estágio (**RF07**) e processar a mudança de estados do workflow (conforme o  **RNF09**).    
+- **Service:** Camada onde reside o **Motor de Regras** mencionado na visão geral do projeto. É responsável pela lógica de negócio complexa, como validar se a jornada é compatível com as aulas, verificar se o aluno está apto para o estágio (**RF07**) e processar a mudança de estados do workflow (conforme o **RNF09**).
 
--   **Model :**  Gerencia a persistência das entidades no banco de dados relacional, garantindo a integridade transacional e mantendo a trilha de auditoria e o histórico de ações dos usuários (**RF13**).
+- **Model:** Gerencia a persistência das entidades no banco de dados relacional, garantindo a integridade transacional e mantendo a trilha de auditoria e o histórico de ações dos usuários (**RF13**).
+
 ## 🎀 Objetivos de Arquitetura e Restrições
 
-### 💕  Objetivos
+### 💕 Objetivos
 
-<p align = "justify">
-
--  <strong>Segurança:</strong> O sistema deve garantir que o acesso a documentos e dados sensíveis seja restrito via autenticação e autorização baseada em perfis (RBAC), protegendo uploads e downloads contra acessos indevidos. 
-  
-  -   <strong>Persistência:</strong> Utilização de um banco de dados relacional para garantir a integridade transacional das aprovações e o armazenamento do histórico completo de auditoria de cada processo de estágio. 
- -   <strong>Privacidade:</strong> Tratamento de dados pessoais e documentos seguindo os princípios de minimização e necessidade, com retenção segura conforme as normas institucionais. 
-  -   <strong>Middlewares:</strong> Uso de middlewares no Backend para interceptar requisições, validando tokens de autenticação e garantindo que apenas usuários autorizados acessem rotas críticas antes de chegarem à lógica de negócio. 
- -   <strong>Desempenho:</strong> As operações de consulta de processos e carregamento de listas devem responder em tempo adequado para o uso administrativo, com feedback visual (progress bar) durante o upload de documentos pesados. 
--  <strong>Reusabilidade:</strong> No Frontend, uso de componentes modulares para formulários e cards de status. No Backend, a lógica de validação acadêmica é centralizada em módulos/serviços reutilizáveis por diferentes tipos de curso. </p>  
+- **Segurança:** O sistema deve garantir que o acesso a documentos e dados sensíveis seja restrito via autenticação e autorização baseada em perfis (RBAC), protegendo uploads e downloads contra acessos indevidos.
+- **Persistência:** Utilização de um banco de dados relacional para garantir a integridade transacional das aprovações e o armazenamento do histórico completo de auditoria de cada processo de estágio.
+- **Privacidade:** Tratamento de dados pessoais e documentos seguindo os princípios de minimização e necessidade, com retenção segura conforme as normas institucionais.
+- **Middlewares:** Uso de middlewares no Backend para interceptar requisições, validando tokens de autenticação e garantindo que apenas usuários autorizados acessem rotas críticas antes de chegarem à lógica de negócio.
+- **Desempenho:** As operações de consulta de processos e carregamento de listas devem responder em tempo adequado para o uso administrativo, com feedback visual (progress bar) durante o upload de documentos pesados.
+- **Reusabilidade:** No Frontend, uso de componentes modulares para formulários e cards de status. No Backend, a lógica de validação acadêmica é centralizada em módulos/serviços reutilizáveis por diferentes tipos de curso.
 
 ### 💕 Restrições
 
-<p align = "justify"> <strong>Tamanho da tela:</strong> A aplicação deve ser responsiva, priorizando o uso em desktops para perfis administrativos e alunos, mas adaptável para visualização de status em dispositivos móveis.
+**Tamanho da tela:** A aplicação deve ser responsiva, priorizando o uso em desktops para perfis administrativos e alunos, mas adaptável para visualização de status em dispositivos móveis.
 
-<strong>Portabilidade:</strong> O sistema deve ser acessível via navegadores modernos, sem necessidade de instalação de plugins locais.
+**Portabilidade:** O sistema deve ser acessível via navegadores modernos, sem necessidade de instalação de plugins locais.
 
 | IE | Edge  | Firefox | Chrome | Safari | Googlebot |
 | -- | ----- | ------- | ------ | ------ | --------- |
 | 11 | >= 14 | >= 52   | >= 49  | >= 10  | Sim       |
 
-<strong>Serviços:</strong> Os serviços oferecidos dependem da disponibilidade da API Django e do serviço de armazenamento de arquivos (Media Storage) para os documentos.
+**Serviços:** Os serviços oferecidos dependem da disponibilidade da API Django e do serviço de armazenamento de arquivos (Media Storage) para os documentos.
 
-<strong>Acesso à internet:</strong> A aplicação está limitada apenas à conexão com internet, não possuindo modo offline funcional devido à necessidade de validação de documentos em tempo real.
-
-</p>
+**Acesso à internet:** A aplicação está limitada apenas à conexão com internet, não possuindo modo offline funcional devido à necessidade de validação de documentos em tempo real.
 
 ### 💕 Ferramentas Utilizadas
 
--   **Python**: Linguagem de programação robusta utilizada no desenvolvimento do Back-end.
--   **Django**: Framework web de alto nível para o desenvolvimento ágil da API e do motor de regras acadêmicas.
--   **PostgreSQL/MySQL**: Banco de dados relacional utilizado para persistência e integridade dos dados.
--   **Figma**: Ferramenta utilizada para o design de interface (UI) e prototipagem do fluxo do usuário.
--   **Git/GitHub**: Sistema de controle de versão para colaboração do time e versionamento do código-fonte.
+- **Python:** Linguagem de programação robusta utilizada no desenvolvimento do Back-end.
+- **Django:** Framework web de alto nível para o desenvolvimento ágil da API e do motor de regras acadêmicas.
+- **PostgreSQL/MySQL:** Banco de dados relacional utilizado para persistência e integridade dos dados.
+- **Figma:** Ferramenta utilizada para o design de interface (UI) e prototipagem do fluxo do usuário.
+- **Git/GitHub:** Sistema de controle de versão para colaboração do time e versionamento do código-fonte.
 
 ## 🎀 Visão de Caso de Uso
 
-<p align = "justify">
->> a inserir
-</p>
+> A inserir.
 
 ## 🎀 Visão de Implementação
 
-<p align = "justify"> A implementação do sistema segue o paradigma de Orientação a Objetos, utilizando o ORM (Object-Relational Mapping) do Django para mapear as classes de domínio para o banco de dados relacional. Abaixo, o Diagrama de Classes detalha a estrutura das entidades, seus atributos e os métodos principais que regem o ciclo de vida do estágio. </p>
->>inserir diagrama de classes
+A implementação do sistema segue o paradigma de Orientação a Objetos, utilizando o ORM (Object-Relational Mapping) do Django para mapear as classes de domínio para o banco de dados relacional. Abaixo, o Diagrama de Classes detalha a estrutura das entidades, seus atributos e os métodos principais que regem o ciclo de vida do estágio.
+
+> Inserir diagrama de classes.
 
 ## 🎀 Visão de Dados
+
 A persistência utiliza um **banco de dados relacional** para garantir a integridade das transações (como a aprovação de um documento que altera o status do processo). O sistema gerencia não apenas dados textuais, mas também o versionamento e armazenamento de arquivos (PDFs) vinculados a cada etapa do estágio (**RF20**).
 
 ## 🎀 Tamanho e Desempenho
+
 O sistema é projetado para suportar múltiplos processos simultâneos sem perda de consistência (**RNF03**). As consultas de status e listagens são otimizadas para o uso administrativo diário, e o sistema de upload deve gerenciar arquivos de documentação sem travar a interface do usuário (**RNF03**).
 
 ## 🎀 Qualidade
+
 A qualidade é assegurada pela **rastreabilidade total** (cada alteração de status registra quem a fez e quando) e pela **validade normativa**. O sistema impede que processos avancem sem os documentos obrigatórios (**RF07**), reduzindo erros operacionais e garantindo que o IBMEC esteja sempre em conformidade com a Lei do Estágio.
 
 ## 🎀 Autor(es)
+
 | Data | Versão | Descrição | Autor(es) |
 | -- | -- | -- | -- |
 | 11/04/2026 | 1.0 | Criação do documento | Letícia Valladão |
 
 ## 🎀 Dados do Documento
+
 > id: DAR-Estagios <br/> title: DAR do Site para Gerenciamento de Estágios para a IBMEC
-
-
-
-                     


### PR DESCRIPTION
  ## O que foi feito

  Este PR corrige a formatação da página **Elaboração > Requisitos**, localizada
  em `docs/Elaboracao/das.md`.

  A alteração ajusta a estrutura Markdown do documento para que o conteúdo seja
  renderizado corretamente tanto no `mkdocs serve` quanto na visualização do
  GitHub.

  ## Principais ajustes

  - Remoção de blocos HTML `<p align="justify">` que impediam listas e tabelas
  de serem interpretadas corretamente.
  - Conversão de marcações HTML simples para Markdown puro.
  - Correção da marcação de negrito em `ato educativo supervisionado`.
  - Ajuste de listas, títulos, quebras de linha e placeholders.
  - Correção pontual de espaçamento em `Aluno, Empresa`.

  ## Observação

  O conteúdo textual foi preservado. A mudança é focada em estrutura e
  renderização, sem alterar o significado do documento.