### PR TITLE
docs: documentação da API no MkDocs (issue #48)

### DIFF
--- a/docs/Construcao/api/autenticacao.md
+++ b/docs/Construcao/api/autenticacao.md
@@ -1,0 +1,274 @@
+# Autenticação
+
+A API IBMEC Estágios utiliza autenticação por **token** baseada em `rest_framework.authtoken` (DRF Token Authentication). Não há sessão, nem cookie, nem CSRF: cada cliente obtém um token via registro ou login e o envia no header `Authorization` em todas as requisições subsequentes. O token é opaco, persistente até logout, e está vinculado a um único `Usuario`.
+
+## Visão geral
+
+Pseudo-fluxo do ciclo de autenticação:
+
+```
+Cliente ─► POST /api/auth/register/  ─► 201 { token, id, tipo }
+              │
+              └─ ou, se já tem conta:
+                 POST /api/auth/login/ ─► 200 { token, id, tipo, nome }
+                                                │
+                                                ▼
+Cliente ─► (toda request seguinte)
+           Header: Authorization: Token <key>
+                                                │
+                                                ▼
+Cliente ─► POST /api/auth/logout/    ─► 200 { mensagem }
+           (invalida o token atual)
+```
+
+Enquanto o token estiver válido, ele é a credencial única do cliente. Não há expiração automática; a invalidação acontece em `logout` ou por ação administrativa.
+
+## Tipos de usuário
+
+O campo `tipo` em `Usuario` define o papel do ator no sistema e direciona qual perfil (`Aluno`, `Coordenador`, `SupervisorEmpresa`) é criado em conjunto. Administradores não usam `tipo`: são `Usuario` com `is_staff=True` e/ou `is_superuser=True`, criados via `python manage.py createsuperuser`.
+
+| `tipo` | Quem é | O que faz no sistema |
+| --- | --- | --- |
+| `aluno` | Estudante do IBMEC matriculado em estágio obrigatório | Cria processos de estágio, anexa documentos, acompanha decisões, cancela o próprio processo |
+| `coordenador` | Coordenador acadêmico de um ou mais cursos | Aprova, rejeita, solicita correção, ativa e encerra processos dos alunos dos cursos sob sua coordenação |
+| `supervisor_empresa` | Profissional da empresa concedente | Visualiza processos vinculados à sua empresa; ações de acompanhamento ficam fora do escopo desta entrega |
+| _admin_ (sem `tipo`) | Usuário com `is_staff=True`, criado via `createsuperuser` | Acesso total a todos os recursos e a qualquer transição da máquina de estados |
+
+## POST /api/auth/register/
+
+Cria simultaneamente o `Usuario` e o perfil correspondente ao `tipo`, e devolve um token pronto para uso.
+
+- **Auth requerida:** não (`AllowAny`).
+- **Content-Type:** `application/json`.
+
+### Body comum (todos os tipos)
+
+| Campo | Tipo | Obrigatório | Observação |
+| --- | --- | --- | --- |
+| `tipo` | string | sim | `aluno`, `coordenador` ou `supervisor_empresa` |
+| `username` | string | sim | Identificador único de login |
+| `password` | string | sim | Senha em texto plano (será hasheada pelo Django) |
+| `nome` | string | recomendado | Nome civil do usuário |
+| `email_institucional` | string (email) | recomendado | Email institucional do usuário |
+
+### Campos extras por tipo
+
+#### `tipo = "aluno"`
+
+| Campo | Tipo | Obrigatório | Observação |
+| --- | --- | --- | --- |
+| `cpf` | string | sim | Único na base de alunos |
+| `rg` | string | não | Texto livre |
+| `coeficiente_rendimento` | decimal | não | Default `0` |
+| `curso_id` | int (FK `Curso`) | não | Recomendado para que o sistema atribua coordenador automaticamente ao criar processo |
+| `matriculado_estagio` | bool | não | Default `false` |
+
+#### `tipo = "coordenador"`
+
+| Campo | Tipo | Obrigatório | Observação |
+| --- | --- | --- | --- |
+| `departamento` | string | sim | Não pode ser vazio |
+
+#### `tipo = "supervisor_empresa"`
+
+| Campo | Tipo | Obrigatório | Observação |
+| --- | --- | --- | --- |
+| `empresa_id` | int (FK `EmpresaConcedente`) | sim | Deve referenciar empresa existente |
+| `cargo` | string | não | Texto livre |
+
+### Resposta de sucesso
+
+`201 Created`:
+
+```json
+{
+  "token": "c2f1a9d4e3b8...",
+  "id": 17,
+  "tipo": "aluno"
+}
+```
+
+### Erros comuns
+
+`400 Bad Request`:
+
+```json
+{ "erro": "username e password são obrigatórios." }
+```
+
+```json
+{ "erro": "campo \"departamento\" é obrigatório para coordenador." }
+```
+
+```json
+{ "erro": "campo \"empresa_id\" é obrigatório para supervisor_empresa." }
+```
+
+```json
+{ "erro": "EmpresaConcedente não encontrada." }
+```
+
+```json
+{ "erro": "tipo deve ser \"aluno\", \"coordenador\" ou \"supervisor_empresa\"." }
+```
+
+Erros de integridade de banco (`username` duplicado, `cpf` duplicado, etc.) também retornam `400` com a mensagem da exceção em `erro`.
+
+### Exemplos curl
+
+Aluno:
+
+```bash
+curl -X POST http://localhost:8000/api/auth/register/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tipo": "aluno",
+    "username": "ana.lima",
+    "password": "senha-forte-123",
+    "nome": "Ana Lima",
+    "email_institucional": "ana.lima@al.ibmec.edu.br",
+    "cpf": "123.456.789-00",
+    "curso_id": 1,
+    "coeficiente_rendimento": 8.4
+  }'
+```
+
+Coordenador:
+
+```bash
+curl -X POST http://localhost:8000/api/auth/register/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tipo": "coordenador",
+    "username": "prof.souza",
+    "password": "senha-forte-123",
+    "nome": "Carlos Souza",
+    "email_institucional": "carlos.souza@ibmec.edu.br",
+    "departamento": "Computação"
+  }'
+```
+
+Supervisor de empresa:
+
+```bash
+curl -X POST http://localhost:8000/api/auth/register/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tipo": "supervisor_empresa",
+    "username": "marcia.acme",
+    "password": "senha-forte-123",
+    "nome": "Márcia Pereira",
+    "email_institucional": "marcia@acme.com",
+    "empresa_id": 3,
+    "cargo": "Gerente de RH"
+  }'
+```
+
+## POST /api/auth/login/
+
+Autentica `username`/`password` e devolve o token persistente do usuário (cria um, se ainda não existir).
+
+- **Auth requerida:** não (`AllowAny`).
+
+### Body
+
+```json
+{
+  "username": "ana.lima",
+  "password": "senha-forte-123"
+}
+```
+
+### Resposta de sucesso
+
+`200 OK`:
+
+```json
+{
+  "token": "c2f1a9d4e3b8...",
+  "id": 17,
+  "tipo": "aluno",
+  "nome": "Ana Lima"
+}
+```
+
+### Erro
+
+`401 Unauthorized`:
+
+```json
+{ "erro": "Credenciais inválidas." }
+```
+
+### Exemplo curl
+
+```bash
+curl -X POST http://localhost:8000/api/auth/login/ \
+  -H "Content-Type: application/json" \
+  -d '{"username": "ana.lima", "password": "senha-forte-123"}'
+```
+
+## POST /api/auth/logout/
+
+Invalida o token do usuário autenticado, removendo-o da base. O mesmo usuário receberá outro token na próxima chamada a `login` ou `register`.
+
+- **Auth requerida:** sim (`IsAuthenticated`).
+- **Header obrigatório:** `Authorization: Token <key>`.
+
+### Resposta de sucesso
+
+`200 OK`:
+
+```json
+{ "mensagem": "Logout realizado com sucesso." }
+```
+
+A view captura silenciosamente o caso em que o token já foi removido, retornando a mesma mensagem.
+
+### Exemplo curl
+
+```bash
+curl -X POST http://localhost:8000/api/auth/logout/ \
+  -H "Authorization: Token c2f1a9d4e3b8..."
+```
+
+## Usando o token em requests
+
+Toda rota protegida exige o header:
+
+```
+Authorization: Token <key>
+```
+
+Note o prefixo literal `Token` (com letra maiúscula), seguido de espaço e da chave devolvida pelo `register`/`login`. Não use `Bearer`.
+
+Exemplo de listagem de processos de estágio autenticada como aluno:
+
+```bash
+curl -X GET http://localhost:8000/api/processos-estagio/ \
+  -H "Authorization: Token c2f1a9d4e3b8..." \
+  -H "Accept: application/json"
+```
+
+Requisições sem o header (ou com token inválido/inexistente) retornam `401 Unauthorized`. Requisições com token válido mas sem permissão para o recurso retornam `403 Forbidden`.
+
+## Permissões por papel (resumo)
+
+Cada papel tem um conjunto típico de ações autorizadas pelas classes em `app/permissions.py` e pela lógica de `ProcessoEstagioViewSet`. O detalhamento por endpoint está em [`endpoints.md`](endpoints.md).
+
+| Papel | Ações típicas |
+| --- | --- |
+| Aluno | Cria o próprio processo de estágio, lista/visualiza os próprios processos e documentos, envia documentos, cancela o próprio processo |
+| Coordenador | Lista cursos sob sua coordenação, lista processos dos alunos desses cursos, aprova/rejeita/solicita correção/ativa/encerra esses processos |
+| Supervisor de empresa | Lista processos vinculados à sua `EmpresaConcedente`, consulta documentos desses processos |
+| Admin | Acesso irrestrito a todos os recursos e a qualquer transição da máquina de estados |
+
+## OAuth Microsoft
+
+A carcaça do `django-allauth` (com provider Microsoft) está instalada em `mysite/settings.py` como preparação para integração futura ao Azure AD do IBMEC. Porém o App Registration correspondente não está configurado: não há `client_id`/`client_secret` válidos, nem callback registrado no portal Azure. Por isso, autenticação via conta institucional Microsoft está **fora do escopo desta entrega** — a única autenticação operacional é o fluxo Token Auth descrito acima.
+
+## Autor(es)
+
+| Data | Versão | Descrição | Autor(es) |
+| -- | -- | -- | -- |
+| 28/05/2026 | 1.0 | Criação do documento | João Gabriel Teodósio |

--- a/docs/Construcao/api/endpoints.md
+++ b/docs/Construcao/api/endpoints.md
@@ -1,0 +1,336 @@
+# Endpoints da API
+
+A API IBMEC Estágios expõe **27 endpoints** organizados em **8 recursos** (3 de autenticação + 7 ViewSets REST registrados no `DefaultRouter`). Este documento traz a referência tabular dos recursos publicados pela PR [#47](https://github.com/Projetos-de-Extensao/PBE_26.1_8002_I/pull/47); para os contratos de payload exatos, **a fonte de verdade é o Swagger UI em `/api/docs/`**, gerado pelo `drf-spectacular` a partir dos serializers do código.
+
+## Tabela mestre
+
+Legenda de status: `✓ pronto` = entregue na PR #47 · `⚠ parcial` = caminho feliz pronto, faltam validações secundárias · `✗ não implementado` = previsto para entregas futuras.
+
+| Método | URL | Quem pode | Descrição | Status |
+| -- | -- | -- | -- | -- |
+| POST | `/api/auth/register/` | Anônimo | Cria `Usuario` + perfil (`aluno`, `coordenador` ou `supervisor_empresa`) e devolve token DRF | ✓ pronto |
+| POST | `/api/auth/login/` | Anônimo | Autentica username/password, retorna token + dados básicos | ✓ pronto |
+| POST | `/api/auth/logout/` | Autenticado | Invalida o token do usuário corrente | ✓ pronto |
+| GET | `/api/cursos/` | Autenticado | Lista cursos (coord vê só os seus, admin vê todos) | ✓ pronto |
+| POST | `/api/cursos/` | Admin | Cria curso | ✓ pronto |
+| GET | `/api/cursos/{id}/` | Autenticado | Detalha curso | ✓ pronto |
+| PUT/PATCH | `/api/cursos/{id}/` | Admin | Atualiza curso | ✓ pronto |
+| DELETE | `/api/cursos/{id}/` | Admin | Remove curso | ✓ pronto |
+| GET | `/api/cursos/meus_alunos/` | Coordenador | Alunos do(s) curso(s) sob coordenação | ✗ não implementado |
+| GET | `/api/cursos/processos_pendentes/` | Coordenador | Processos `PENDENTE` aguardando análise | ✗ não implementado |
+| GET | `/api/empresas/` | Autenticado | Lista empresas concedentes (filtros `?aprovada=` e `?busca=`) | ✓ pronto |
+| POST | `/api/empresas/` | Admin | Cadastra empresa concedente | ✓ pronto |
+| GET | `/api/empresas/{id}/` | Autenticado | Detalha empresa | ✓ pronto |
+| PUT/PATCH | `/api/empresas/{id}/` | Admin | Atualiza empresa | ✓ pronto |
+| DELETE | `/api/empresas/{id}/` | Admin | Remove empresa | ✓ pronto |
+| GET | `/api/empresas/meu_perfil/` | Supervisor de empresa | Empresa do supervisor logado | ✗ não implementado |
+| GET/POST | `/api/alunos/` | Autenticado (isolado) | Lista/cria alunos com escopo por papel | ✓ pronto |
+| GET/PUT/PATCH/DELETE | `/api/alunos/{id}/` | Autenticado (isolado) | CRUD por ID, respeitando isolamento | ✓ pronto |
+| GET | `/api/alunos/meu_perfil/` | Aluno | Perfil próprio do aluno logado | ✗ não implementado |
+| GET/POST | `/api/coordenadores/` | Autenticado (isolado) | Lista/cria coordenadores | ✓ pronto |
+| GET/PUT/PATCH/DELETE | `/api/coordenadores/{id}/` | Autenticado (isolado) | CRUD por ID | ✓ pronto |
+| GET/POST | `/api/supervisores-empresa/` | Autenticado (isolado) | Lista/cria supervisores | ✓ pronto |
+| GET/PUT/PATCH/DELETE | `/api/supervisores-empresa/{id}/` | Autenticado (isolado) | CRUD por ID | ✓ pronto |
+| GET/POST | `/api/documentos/` | Autenticado (isolado) | Lista/cria documentos | ⚠ parcial |
+| GET/PUT/PATCH/DELETE | `/api/documentos/{id}/` | Autenticado (isolado) | CRUD por ID | ⚠ parcial |
+| GET | `/api/processos-estagio/` | Autenticado (isolado) | Lista processos visíveis ao usuário | ✓ pronto |
+| POST | `/api/processos-estagio/` | Aluno | Abre processo (`status=PENDENTE`, coord automático) | ✓ pronto |
+| GET | `/api/processos-estagio/{id}/` | Dono / Coord / Supervisor / Admin | Detalha processo | ✓ pronto |
+| PUT/PATCH | `/api/processos-estagio/{id}/` | Dono / Admin | Atualiza dados livres do processo | ✓ pronto |
+| DELETE | `/api/processos-estagio/{id}/` | Admin | Remove processo | ✓ pronto |
+| POST | `/api/processos-estagio/{id}/alterar_status/` | Conforme transição | Transição validada pela state machine | ✓ pronto |
+| GET | `/api/processos-estagio/{id}/documentos/` | Autenticado (isolado) | Lista documentos do processo | ✓ pronto |
+| POST | `/api/processos-estagio/{id}/gerar-tce/` | Coordenador | Gera PDF do Termo de Compromisso de Estágio | ✗ não implementado |
+| POST | `/api/processos-estagio/{id}/gerar-termo-realizacao/` | Coordenador | Gera PDF do Termo de Realização | ✗ não implementado |
+
+## Autenticação
+
+A camada de autenticação usa token DRF (`rest_framework.authtoken`). Detalhes do header `Authorization: Token <chave>`, ciclo de vida do token e estrutura dos payloads de cadastro estão em [Autenticação](autenticacao.md).
+
+### POST `/api/auth/register/`
+
+Cria um `Usuario` + perfil vinculado conforme o campo `tipo` (`aluno`, `coordenador`, `supervisor_empresa`). Devolve token DRF pronto pra usar. Body comum: `tipo`, `username`, `password`, `nome`, `email_institucional`. Campos extras variam por tipo (CPF para aluno, departamento para coordenador, empresa_id para supervisor). Veja [Autenticação](autenticacao.md#post-apiauthregister).
+
+### POST `/api/auth/login/`
+
+Autentica username + password via `django.contrib.auth.authenticate` e devolve `{token, id, tipo, nome}`. Falha com `401 Unauthorized` se as credenciais não baterem. Veja [Autenticação](autenticacao.md#post-apiauthlogin).
+
+### POST `/api/auth/logout/`
+
+Apaga o token DRF do usuário corrente. Próximas requisições com aquele token retornam `401`. Veja [Autenticação](autenticacao.md#post-apiauthlogout).
+
+## Processos de Estágio (foco da PR #47)
+
+Recurso central da entrega. `ProcessoEstagioViewSet` aplica RBAC no `get_queryset` (cada papel só enxerga o que lhe pertence), troca de serializer conforme a ação e expõe duas `@action` customizadas.
+
+### GET `/api/processos-estagio/`
+
+Lista paginada dos processos visíveis ao usuário. O filtro implícito por papel é:
+
+- **Aluno** — somente os próprios processos (`filter(aluno=aluno)`).
+- **Supervisor de empresa** — processos da empresa em que está vinculado (`filter(empresa=supervisor.empresa)`).
+- **Coordenador** — processos de alunos dos cursos que coordena (`filter(aluno__curso__coordenador=coord)`).
+- **Admin** — todos.
+- **Qualquer outro caso** — `.none()` (negação por default).
+
+Permissões: `IsAuthenticated`. Os filtros de papel acontecem no queryset, não nas permissions.
+
+### POST `/api/processos-estagio/`
+
+Cria um processo. Apenas alunos podem chamar — se o usuário não tem perfil `Aluno`, o `perform_create` levanta `PermissionDenied`. O ViewSet seta automaticamente `aluno` = aluno logado, `status` = `PENDENTE` e `coordenador` = coordenador do curso do aluno (quando existir).
+
+Payload de exemplo:
+
+```json
+{
+  "empresa": 4,
+  "supervisor": 7,
+  "horas_semanais": 20,
+  "data_inicio_prevista": "2026-06-15",
+  "data_fim_prevista": "2026-12-15",
+  "plano_atividades": "Desenvolvimento de microserviços em Python."
+}
+```
+
+Resposta `201 Created`:
+
+```json
+{
+  "id": 12,
+  "aluno": 3,
+  "empresa": 4,
+  "supervisor": 7,
+  "coordenador": 2,
+  "status": "PENDENTE",
+  "horas_semanais": 20,
+  "data_inicio_prevista": "2026-06-15",
+  "data_fim_prevista": "2026-12-15",
+  "plano_atividades": "Desenvolvimento de microserviços em Python.",
+  "justificativa_rejeicao": ""
+}
+```
+
+Permissões: `IsAuthenticated` + perfil `Aluno` verificado em `perform_create`.
+
+### GET `/api/processos-estagio/{id}/`
+
+Detalha um processo. O acesso é validado duplamente: pelo queryset (papel) e pelo `get_object` (existência). Se o ID não está no queryset filtrado, o DRF responde `404 Not Found` — não vaza a existência de processos alheios.
+
+Resposta `200 OK` traz o mesmo formato do `POST`, com os relacionamentos resolvidos por `select_related`.
+
+### POST `/api/processos-estagio/{id}/alterar_status/`
+
+Endpoint mais delicado da entrega. Executa quatro checagens em ordem antes de persistir:
+
+1. **Transição válida** pelo mapa em `state_machine.py` (`transicoes_validas(processo.status)`).
+2. **Permissão por papel** — aluno só pode `RASCUNHO→PENDENTE` ou `*→CANCELADO`; coordenador só pode emitir `APROVADO`, `REJEITADO`, `CORRECAO_SOLICITADA`, `ATIVO` ou `ENCERRADO`.
+3. **Validação do serializer** `AlterarStatusSerializer` — exige justificativa quando `novo_status=REJEITADO` (RN11).
+4. **Persistência** + refresh + retorno do processo serializado por inteiro.
+
+Payload mínimo:
+
+```json
+{
+  "status": "APROVADO"
+}
+```
+
+Payload de rejeição (justificativa obrigatória):
+
+```json
+{
+  "status": "REJEITADO",
+  "justificativa_rejeicao": "Plano de atividades não condiz com o curso do aluno."
+}
+```
+
+Resposta de erro em transição inválida (`400 Bad Request`):
+
+```json
+{
+  "status": "Transição inválida: APROVADO → RASCUNHO.",
+  "estado_atual": "APROVADO",
+  "transicoes_validas": ["ATIVO", "CANCELADO", "REJEITADO"]
+}
+```
+
+Veja o mapa completo em [Máquina de Estados](state-machine.md) e a lista de regras de negócio aplicadas em [Regras de Negócio](regras-negocio.md).
+
+### GET `/api/processos-estagio/{id}/documentos/`
+
+Lista todos os `DocumentoProcesso` vinculados ao processo, ordenados por `-data_upload`. Reutiliza o `DocumentoProcessoSerializer`. Permissões: o `get_object` aplica o filtro de papel; quem não tem visão do processo recebe `404`.
+
+Resposta `200 OK`:
+
+```json
+[
+  {
+    "id": 18,
+    "processo": 12,
+    "tipo": "TCE",
+    "arquivo": "/media/documentos/tce_12.pdf",
+    "enviado_por": 5,
+    "data_upload": "2026-05-27T14:32:11Z",
+    "status": "PENDENTE",
+    "versao": 1
+  }
+]
+```
+
+## Cursos
+
+CRUD básico via `CursoViewSet`. Escrita (`POST`/`PUT`/`PATCH`/`DELETE`) exige `IsAdminOrReadOnly`; leitura é liberada para autenticados, mas o `get_queryset` filtra: coordenador vê apenas cursos onde é responsável (`filter(coordenador=coordenador)`), admin vê tudo.
+
+Campos do modelo (referência rápida):
+
+```python
+nome: CharField
+coordenador: ForeignKey(Coordenador, null=True)
+carga_horaria_minima_total: PositiveIntegerField
+carga_horaria_maxima_diaria: PositiveIntegerField (default=6)
+```
+
+Permissões resumidas:
+
+| Ação | Aluno | Coordenador | Supervisor | Admin |
+| -- | -- | -- | -- | -- |
+| Listar/detalhar | ✓ (todos) | ✓ (só os seus) | ✓ (todos) | ✓ |
+| Criar/editar/remover | ✗ | ✗ | ✗ | ✓ |
+
+## Empresas Concedentes
+
+`EmpresaConcedenteViewSet` com `IsAdminOrReadOnly`: qualquer autenticado lê, só admin escreve. Suporta **dois filtros via query string**:
+
+| Parâmetro | Tipo | Comportamento |
+| -- | -- | -- |
+| `?aprovada=true` ou `?aprovada=false` | bool (aceita `true`/`1`) | Filtra por `aprovada_ibmec` |
+| `?busca=texto` | string | `razao_social__icontains=texto` |
+
+Exemplo combinando filtros:
+
+```bash
+GET /api/empresas/?aprovada=true&busca=tecnologia
+```
+
+Campos persistidos (RN10):
+
+```python
+cnpj: CharField unique
+razao_social: CharField
+areas_atuacao: TextField
+localizacao: CharField
+email_contato: EmailField
+aprovada_ibmec: BooleanField (default=False)
+```
+
+## Alunos
+
+`AlunoViewSet` aplica isolamento por papel no `get_queryset`:
+
+- **Admin** — todos os alunos.
+- **Aluno** — apenas o próprio registro (`filter(pk=aluno.pk)`).
+- **Coordenador** — alunos dos cursos que coordena (`filter(curso__coordenador=coord)`).
+- **Outros casos** — `.none()`.
+
+A leitura usa `select_related('usuario', 'curso')` para evitar N+1 ao montar a listagem.
+
+Resposta de exemplo (`GET /api/alunos/{id}/`):
+
+```json
+{
+  "id": 3,
+  "usuario": {
+    "id": 11,
+    "username": "joao.silva",
+    "nome": "João Silva",
+    "email_institucional": "joao.silva@ibmec.edu.br",
+    "tipo": "aluno"
+  },
+  "cpf": "123.456.789-00",
+  "rg": "12.345.678-9",
+  "coeficiente_rendimento": "8.50",
+  "curso": 2,
+  "matriculado_estagio": true
+}
+```
+
+## Coordenadores
+
+`CoordenadorViewSet` segue o mesmo padrão: admin vê todos, coordenador vê só a si mesmo, outros papéis recebem `.none()`. Útil para coordenadores conferirem seu próprio cadastro e admins gerirem a equipe acadêmica.
+
+## Supervisores de Empresa
+
+`SupervisorEmpresaViewSet` com a mesma estrutura: admin vê todos, supervisor vê só a si mesmo, demais recebem `.none()`. O `select_related('usuario', 'empresa')` traz a empresa vinculada em uma query.
+
+## Documentos
+
+`DocumentoProcessoViewSet` gerencia os arquivos vinculados aos processos (`TCE`, `APOLICE`, `RELATORIO_PARCIAL`, `RELATORIO_FINAL`, `AVALIACAO_EMPRESA`, `TERMO_REALIZACAO`, `OUTRO`).
+
+Isolamento por papel no queryset:
+
+- **Aluno** — documentos dos próprios processos.
+- **Supervisor de empresa** — documentos dos processos da empresa em que atua.
+- **Coordenador** — documentos dos processos de alunos dos cursos sob coordenação.
+- **Admin** — todos.
+
+No `perform_create`, o ViewSet seta `enviado_por = request.user` automaticamente, garantindo trilha de auditoria (RF13) sem confiar em campo do cliente.
+
+Status `⚠ parcial` porque o upload funciona, mas a validação de MIME e tamanho do arquivo (RF05 detalhado) é parte da entrega da Pessoa 5.
+
+### Comportamento de filtros combinados
+
+Quando o usuário tem mais de um perfil ativo (caso raro em produção, mas suportado pelo modelo), o `get_queryset` resolve a precedência nesta ordem em cada ViewSet:
+
+1. `is_admin(user)` — se for admin, retorna tudo e sai.
+2. `get_aluno(user)` — se houver perfil `Aluno`, filtra para o próprio aluno.
+3. `get_supervisor(user)` — se houver perfil `SupervisorEmpresa`, filtra pela empresa.
+4. `get_coordenador(user)` — se houver perfil `Coordenador`, filtra pelos cursos coordenados.
+5. Nada bateu → `.none()`.
+
+Ou seja, a ordem é: admin > aluno > supervisor > coordenador. Em produção, cada `Usuario` deve ter apenas um perfil — o admin Django facilita auditar inconsistências.
+
+## Resumo de permissões por papel
+
+Tabela cruzada para consulta rápida. Marcador `R` = leitura, `W` = escrita (criar/atualizar/remover), `–` = sem acesso.
+
+| Recurso | Aluno | Coordenador | Supervisor | Admin |
+| -- | -- | -- | -- | -- |
+| `/api/cursos/` | R | R (só seus) | R | R+W |
+| `/api/empresas/` | R | R | R | R+W |
+| `/api/alunos/` | R (si) | R (alunos dos seus cursos) + W limitado | – | R+W |
+| `/api/coordenadores/` | – | R (si) | – | R+W |
+| `/api/supervisores-empresa/` | – | – | R (si) | R+W |
+| `/api/documentos/` | R+W (próprios) | R (escopo) | R+W (escopo) | R+W |
+| `/api/processos-estagio/` | R (próprios) + criar | R (escopo) + transições | R (escopo) | R+W |
+
+A coluna "escopo" significa: documentos/processos do círculo de cursos (coordenador) ou da empresa (supervisor), nunca de terceiros.
+
+## Documentação interativa
+
+Para explorar payloads exatos, testar requisições com um botão "Try it out" e inspecionar o JSON OpenAPI bruto, acesse a documentação interativa servida pelo `drf-spectacular`:
+
+- Swagger UI — [`/api/docs/`](http://localhost:8000/api/docs/)
+- Redoc — [`/api/redoc/`](http://localhost:8000/api/redoc/)
+- Schema OpenAPI 3 (JSON) — [`/api/schema/`](http://localhost:8000/api/schema/)
+
+Tudo é gerado a partir dos ViewSets, Serializers e docstrings do código. Mudou o serializer? Recarregue o Swagger.
+
+## Fora do escopo desta entrega
+
+A PR #47 entrega a fatia vertical da Pessoa 1 (núcleo do `ProcessoEstagio`). Os itens abaixo estão planejados, mas **não existem ainda** e devem retornar `404 Not Found` se chamados:
+
+- `GET /api/cursos/meus_alunos/` — agregação para o coordenador (Pessoa 2).
+- `GET /api/cursos/processos_pendentes/` — fila de processos `PENDENTE` para o coordenador (Pessoa 2).
+- `GET /api/alunos/meu_perfil/` — atalho do aluno logado (Pessoa 3).
+- `GET /api/empresas/meu_perfil/` — atalho do supervisor de empresa logado (Pessoa 3).
+- Upload com validação MIME/tamanho em `/api/documentos/` (Pessoa 5).
+- `POST /api/processos-estagio/{id}/gerar-tce/` — gera o Termo de Compromisso de Estágio em PDF (Pessoa 5).
+- `POST /api/processos-estagio/{id}/gerar-termo-realizacao/` — gera o Termo de Realização em PDF (Pessoa 5).
+
+Esses endpoints serão abertos em PRs subsequentes, cada um com sua issue dedicada.
+
+## Autor(es)
+
+| Data | Versão | Descrição | Autor(es) |
+| -- | -- | -- | -- |
+| 28/05/2026 | 1.0 | Criação do documento | João Gabriel Teodósio |

--- a/docs/Construcao/api/erros.md
+++ b/docs/Construcao/api/erros.md
@@ -1,0 +1,209 @@
+# Erros — Convenções e Catálogo
+
+Este documento descreve **como a API IBMEC Estágios devolve erros** ao cliente. A filosofia é simples: erros são úteis. Toda resposta de erro deve trazer (1) um código HTTP coerente com o tipo de problema, (2) uma mensagem em português orientada ao usuário ou ao desenvolvedor e, quando aplicável, (3) instruções para o cliente seguir adiante (ex.: lista de transições válidas, indicação de campo com problema). Não existe `500` "silencioso" — qualquer 500 é bug e precisa ser reportado.
+
+## Códigos HTTP usados
+
+| Código                         | Significado neste sistema                                                                                                            | Exemplo de body                                                                  |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| `200 OK`                       | `GET` bem-sucedido ou ação de mutação completada com sucesso (por exemplo `alterar_status` com transição válida).                    | objeto serializado do recurso                                                    |
+| `201 Created`                  | `POST` criou um recurso (processo, usuário via `/api/auth/register/`).                                                               | objeto criado, incluindo `id`                                                    |
+| `400 Bad Request`              | Validação falhou: RN violada, JSON malformado, transição de status inválida, justificativa vazia, campo faltando.                    | `{"detail": "..."}` ou `{"campo": ["msg"]}`                                      |
+| `401 Unauthorized`             | Sem token ou token inválido/expirado.                                                                                                | `{"detail": "Authentication credentials were not provided."}`                    |
+| `403 Forbidden`                | Token OK, mas o papel do usuário **não tem permissão** para a ação solicitada.                                                       | `{"detail": "Sem permissão neste processo."}`                                    |
+| `404 Not Found`                | Recurso não existe **ou** o recurso existe mas o queryset do papel não o enxerga (defesa por filtro — ver `regras-negocio.md`).      | `{"detail": "Not found."}`                                                       |
+| `500 Internal Server Error`    | Bug. Não deveria acontecer; reporte no canal do time com o `request id` e o payload usado.                                           | stack trace (somente em `DEBUG=True`)                                            |
+
+Pontos importantes:
+
+- **404 é também uma forma de proteção.** Quando um aluno tenta acessar `/api/processos-estagio/<id de outro aluno>/`, o queryset filtrado em `ProcessoEstagioViewSet.get_queryset` já remove esse objeto **antes** de o DRF rodar `get_object`. Resultado: o cliente vê `404`, não `403`. Isso é proposital — evita vazamento de informação sobre existência de recursos. Cobertura: `IsolamentoQuerysetTest` em `djangotutorial/app/tests.py`.
+- **403 ocorre depois** do queryset, quando a permission da action (por exemplo `alterar_status`) detecta que o papel não pode disparar aquela transição específica. Cobertura: `test_aluno_nao_pode_aprovar_proprio_400_ou_403`, `test_coord_de_outro_curso_403`.
+
+## Convenções de payload de erro
+
+A API mistura **três formatos** de erro, dependendo de quem está lançando a exceção. Saber identificar cada um economiza tempo de debug.
+
+### Erro de validação de campo (DRF padrão)
+
+Quando o `ModelSerializer` (ou `Serializer`) lança `ValidationError({"campo": "msg"})`, o DRF responde com:
+
+```json
+{
+  "campo": ["msg"]
+}
+```
+
+Note que o valor é sempre uma **lista** de strings, mesmo que haja só uma mensagem. Esse é o formato mais comum em `POST /api/processos-estagio/` quando uma RN bate. Exemplo real (RN09):
+
+```json
+{
+  "empresa": ["RN09: empresa não está aprovada pelo IBMEC."]
+}
+```
+
+Quando o `ValidationError` é lançado sem chave de campo (ex.: RN05), o DRF agrupa em `non_field_errors`:
+
+```json
+{
+  "non_field_errors": [
+    "RN05: aluno já possui um processo de estágio em andamento. Cancele ou aguarde o encerramento antes de abrir outro."
+  ]
+}
+```
+
+### Erro genérico (DRF padrão)
+
+Quando o DRF lança uma exceção sem contexto de campo — autenticação, permissão, recurso não encontrado, método não permitido — o formato é:
+
+```json
+{
+  "detail": "mensagem"
+}
+```
+
+Exemplos:
+
+- `401`: `{"detail": "Authentication credentials were not provided."}`
+- `403`: `{"detail": "Sem permissão neste processo."}` (custom da view `alterar_status`) ou `{"detail": "You do not have permission to perform this action."}` (DRF padrão)
+- `404`: `{"detail": "Not found."}`
+
+### Erro das auth views customizadas
+
+As views `RegisterView` e `LoginView` em `djangotutorial/app/views.py` usam a chave `erro` (em vez de `detail`), por convenção do time:
+
+```json
+{
+  "erro": "Credenciais inválidas."
+}
+```
+
+Casos onde isso aparece:
+
+- Falta `username`/`password` no `POST /api/auth/register/` → `400 + {"erro": "username e password são obrigatórios."}`
+- `tipo` inválido no register → `400 + {"erro": "tipo deve ser 'aluno', 'coordenador' ou 'supervisor_empresa'."}`
+- Coordenador sem `departamento` → `400 + {"erro": "campo \"departamento\" é obrigatório para coordenador."}`
+- Supervisor sem `empresa_id` → `400 + {"erro": "campo \"empresa_id\" é obrigatório para supervisor_empresa."}`
+- Login com credenciais erradas → `401 + {"erro": "Credenciais inválidas."}`
+
+### Erro de transição inválida (custom)
+
+Quando o cliente tenta mover o status para um estado inalcançável, a view `alterar_status` devolve um payload **estruturado** que ajuda o cliente a se corrigir:
+
+```json
+{
+  "status": "Transição inválida: REJEITADO → ATIVO.",
+  "estado_atual": "REJEITADO",
+  "transicoes_validas": []
+}
+```
+
+A chave `transicoes_validas` é uma **lista de estados alcançáveis** a partir do estado atual. Quando o processo está em estado terminal, a lista vem vazia (`[]`). Use esse payload para popular menus de "próxima ação" na UI sem hardcoded.
+
+## Mensagens padronizadas por regra
+
+| Regra      | Mensagem                                                                                                                              |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| RN01       | `RN01: aluno deve estar com matrícula ativa em estágio supervisionado.`                                                               |
+| RN03       | `RN03: excede o limite do curso (Xh/semana).` (onde `X` é o limite calculado do curso)                                                |
+| RN05       | `RN05: aluno já possui um processo de estágio em andamento. Cancele ou aguarde o encerramento antes de abrir outro.`                  |
+| RN09       | `RN09: empresa não está aprovada pelo IBMEC.`                                                                                         |
+| RN11       | `RN11: justificativa obrigatória ao rejeitar uma solicitação.`                                                                        |
+| LEI 30h    | `Limite legal de 30h semanais (Lei 11.788/08).`                                                                                       |
+| DATA       | `Deve ser posterior à data de início.`                                                                                                |
+
+Essas mensagens **fazem parte do contrato** da API. Trocar texto requer atualização nos testes correspondentes (`test_*_rn01`, `test_*_rn03`, etc.) e neste documento. Se você precisar internacionalizar no futuro, use chaves estáveis (`error_code`) ao lado do `message`.
+
+## Exemplos completos por rota
+
+Esta seção traz pares **requisição → resposta** dos cenários de erro mais comuns, para servir de referência rápida quando você estiver depurando o cliente.
+
+### POST `/api/processos-estagio/` — RN01
+
+Aluno sem matrícula ativa tenta abrir processo.
+
+```http
+POST /api/processos-estagio/
+Authorization: Token <token-aluno-nao-matriculado>
+Content-Type: application/json
+
+{"empresa": 1, "horas_semanais": 20, "data_inicio_prevista": "2026-07-01",
+ "data_fim_prevista": "2026-12-31", "plano_atividades": "..."}
+```
+
+Resposta:
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{"aluno": ["RN01: aluno deve estar com matrícula ativa em estágio supervisionado."]}
+```
+
+### POST `/api/processos-estagio/<id>/alterar_status/` — RN11
+
+Coordenador tenta rejeitar sem justificativa.
+
+```http
+POST /api/processos-estagio/42/alterar_status/
+Authorization: Token <token-coordenador>
+Content-Type: application/json
+
+{"status": "REJEITADO"}
+```
+
+Resposta:
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{"justificativa_rejeicao": ["RN11: justificativa obrigatória ao rejeitar uma solicitação."]}
+```
+
+### POST `/api/processos-estagio/<id>/alterar_status/` — Transição inválida
+
+Coordenador tenta reativar um processo já rejeitado.
+
+```http
+POST /api/processos-estagio/42/alterar_status/
+{"status": "ATIVO"}
+```
+
+Resposta `400`:
+
+```json
+{"status": "Transição inválida: REJEITADO → ATIVO.",
+ "estado_atual": "REJEITADO",
+ "transicoes_validas": []}
+```
+
+### GET `/api/processos-estagio/<id-de-outro-aluno>/` — 404 por filtro
+
+Aluno autenticado tenta abrir processo de outro aluno: `GET /api/processos-estagio/77/` retorna `404 Not Found` com `{"detail": "Not found."}` — o queryset filtra o objeto antes de o DRF rodar `get_object`.
+
+## Como debugar erros
+
+Algumas pistas práticas baseadas no que mais ocorre durante o desenvolvimento:
+
+- **`404` quando esperava `403`**. Isso é o `get_queryset` do viewset filtrando o objeto antes da permission rodar. Confirme se o token autenticado pertence ao papel certo e se o objeto realmente "pertence" a esse papel (aluno dono, supervisor da mesma empresa, coordenador do mesmo curso). Veja `ProcessoEstagioViewSet.get_queryset` em `djangotutorial/app/views.py`.
+- **`401` com token aparentemente válido**. Confirme o header: deve ser `Authorization: Token <key>` (com espaço, **sem** prefixo `Bearer`). DRF Token Auth não é JWT.
+- **`400` em `alterar_status` mas sem mensagem clara**. O DRF empilha o erro do `serializer.is_valid(raise_exception=True)` em cima da resposta. Se houver `justificativa_rejeicao` no payload, o erro vem como `{"justificativa_rejeicao": ["..."]}`. Se for transição inválida, vem como `{"status": "...", "estado_atual": "...", "transicoes_validas": [...]}`. Os formatos são distintos.
+- **`500` sem stack trace**. Em produção (`DEBUG=False`), o Django esconde a trace e devolve uma página HTML padrão. Olhe o terminal do `runserver` — é onde a exceção é impressa. Para reproduzir local, rode `manage.py check` antes para descartar erro de configuração.
+- **Resposta JSON difícil de ler**. Use `curl -s ... | python3 -m json.tool` para formatar a saída no terminal. Para `httpie`, basta `http POST ...` que ele já formata.
+- **Validação aparentemente "sumindo"**. Cheque a ordem em `CriarProcessoSerializer.validate`: a primeira regra que falha **interrompe** o método. Se você esperava ver RN05 mas viu RN01, é porque o aluno não estava matriculado e o validador parou antes.
+
+## Padrões de DRF
+
+O sistema segue, por padrão, as convenções do [Django REST Framework](https://www.django-rest-framework.org/api-guide/exceptions/):
+
+- `401`/`403`/`404`/`405` saem do DRF "out of the box", via classes de exceção (`NotAuthenticated`, `PermissionDenied`, `NotFound`, `MethodNotAllowed`).
+- `400` é **principalmente** customizado pela aplicação, via `serializers.ValidationError` ou retorno explícito de `Response(..., status=400)` nas actions.
+- O renderizador padrão é JSON (`rest_framework.renderers.JSONRenderer`); a Browsable API também está habilitada em desenvolvimento e renderiza HTML quando o cliente envia `Accept: text/html`.
+
+Para mais detalhes do contrato global de respostas, veja [o guia de exceções do DRF](https://www.django-rest-framework.org/api-guide/exceptions/) e as referências em [autenticacao.md](autenticacao.md) e na seção [Resumo de permissões por papel](endpoints.md#resumo-de-permissoes-por-papel) de `endpoints.md`.
+
+## Autor(es)
+
+| Data       | Versão | Descrição              | Autor(es)               |
+| ---------- | ------ | ---------------------- | ----------------------- |
+| 28/05/2026 | 1.0    | Criação do documento   | João Gabriel Teodósio   |

--- a/docs/Construcao/api/exemplos.md
+++ b/docs/Construcao/api/exemplos.md
@@ -1,0 +1,644 @@
+# Exemplos práticos — Walkthrough da API
+
+Este documento é executável: cole os comandos sequencialmente em um shell `bash` para reproduzir o fluxo completo do sistema de estágios, desde o seed inicial até o encerramento de um processo. Todos os exemplos usam `curl` contra `http://localhost:8000` e armazenam os tokens em variáveis de shell (`$TOKEN_ALUNO`, `$TOKEN_COORD`) para que os comandos subsequentes funcionem sem edição manual.
+
+## Pré-requisitos
+
+Antes de começar, garanta que o ambiente está pronto:
+
+- **Servidor rodando** em outra aba do terminal:
+  ```bash
+  uv run python djangotutorial/manage.py runserver
+  ```
+  O servidor sobe em `http://localhost:8000`.
+
+- **Superuser criado** (para acessar o Django Admin, se quiser inspecionar o banco):
+  ```bash
+  uv run python djangotutorial/manage.py createsuperuser \
+      --username admin --email admin@ibmec.edu.br
+  ```
+
+- **Migrations aplicadas**. O comando `runserver` aplica automaticamente na primeira execução; caso queira forçar:
+  ```bash
+  uv run python djangotutorial/manage.py migrate
+  ```
+
+- **`python3` no PATH** — usado pelos exemplos para extrair o token JSON da resposta.
+
+- **`curl` no PATH** — qualquer versão recente serve.
+
+Opcionalmente, instale `httpie` (`pip install httpie`) para os exemplos da seção 8 — não é obrigatório.
+
+## Seed inicial via Django shell
+
+Os exemplos assumem o seguinte estado no banco:
+
+- 1 coordenador (`coord1` / departamento Engenharia)
+- 1 curso (Eng. Software, `carga_horaria_maxima_diaria=6` → limite semanal de 30h)
+- 1 empresa aprovada (Tech LTDA, `aprovada_ibmec=True`)
+- 1 empresa NÃO aprovada (Não Aprovada LTDA, `aprovada_ibmec=False`)
+- 1 aluno matriculado (`aluno1`, `matriculado_estagio=True`)
+- 1 aluno NÃO matriculado (`aluno2`, `matriculado_estagio=False`)
+
+Execute o bloco abaixo uma única vez para popular o banco. Ele imprime os IDs gerados ao final — anote-os, especialmente o `emp_ok.pk`, pois o `curl` de criação de processo precisa dele (geralmente `1` se o banco está limpo).
+
+```bash
+uv run python djangotutorial/manage.py shell <<'PY'
+from app.models import Usuario, Coordenador, Curso, EmpresaConcedente, Aluno
+
+cu = Usuario.objects.create_user(
+    username='coord1', password='senha123',
+    tipo='coordenador', nome='Coord Eng',
+)
+coord = Coordenador.objects.create(usuario=cu, departamento='Engenharia')
+
+curso = Curso.objects.create(
+    nome='Eng. Software',
+    carga_horaria_maxima_diaria=6,
+    coordenador=coord,
+)
+
+emp_ok = EmpresaConcedente.objects.create(
+    cnpj='11.111.111/0001-11', razao_social='Tech LTDA',
+    areas_atuacao='TI', localizacao='RJ',
+    email_contato='rh@tech.com', aprovada_ibmec=True,
+)
+emp_no = EmpresaConcedente.objects.create(
+    cnpj='22.222.222/0001-22', razao_social='Não Aprovada LTDA',
+    areas_atuacao='X', localizacao='RJ',
+    email_contato='x@x.com', aprovada_ibmec=False,
+)
+
+u1 = Usuario.objects.create_user(
+    username='aluno1', password='senha123',
+    tipo='aluno', nome='Aluno Um',
+)
+Aluno.objects.create(
+    usuario=u1, cpf='111.111.111-11',
+    curso=curso, matriculado_estagio=True,
+)
+
+u2 = Usuario.objects.create_user(
+    username='aluno2', password='senha123',
+    tipo='aluno', nome='Aluno Dois',
+)
+Aluno.objects.create(
+    usuario=u2, cpf='222.222.222-22',
+    curso=curso, matriculado_estagio=False,
+)
+
+print(f'OK: curso={curso.pk}, emp_ok={emp_ok.pk}, emp_no={emp_no.pk}')
+PY
+```
+
+Saída esperada (os IDs podem variar se o banco já tinha dados):
+
+```
+OK: curso=1, emp_ok=1, emp_no=2
+```
+
+Daqui pra frente, os exemplos assumem `emp_ok=1` e `emp_no=2`. Se forem outros no seu ambiente, substitua nos comandos.
+
+## Walkthrough 1 — Happy path completo
+
+Fluxo do nascimento ao encerramento de um processo de estágio: aluno cria, coordenador aprova, ativa e por fim encerra. Execute na ordem.
+
+### 4.1 Login do aluno (captura `$TOKEN_ALUNO`)
+
+```bash
+TOKEN_ALUNO=$(curl -s -X POST http://localhost:8000/api/auth/login/ \
+  -H "Content-Type: application/json" \
+  -d '{"username": "aluno1", "password": "senha123"}' \
+  | python3 -c "import sys, json; print(json.load(sys.stdin)['token'])")
+
+echo "TOKEN_ALUNO=$TOKEN_ALUNO"
+```
+
+Resposta bruta da API:
+
+```json
+{
+  "token": "9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c",
+  "id": 5,
+  "tipo": "aluno",
+  "nome": "Aluno Um"
+}
+```
+
+### 4.2 Aluno cria processo de estágio
+
+O servidor preenche automaticamente `aluno`, `status=PENDENTE` e `coordenador` (do curso do aluno) — você só envia os dados do estágio em si.
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/ \
+  -H "Authorization: Token $TOKEN_ALUNO" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "empresa": 1,
+    "horas_semanais": 20,
+    "data_inicio_prevista": "2026-07-01",
+    "data_fim_prevista": "2026-12-31",
+    "plano_atividades": "Desenvolvimento de APIs em Django."
+  }' | python3 -m json.tool
+```
+
+Resposta esperada (`201 Created`):
+
+```json
+{
+  "id": 1,
+  "empresa": 1,
+  "horas_semanais": 20,
+  "data_inicio_prevista": "2026-07-01",
+  "data_fim_prevista": "2026-12-31",
+  "plano_atividades": "Desenvolvimento de APIs em Django.",
+  "aluno": 1,
+  "status": "PENDENTE",
+  "coordenador": 1
+}
+```
+
+Anote o `id` do processo retornado (assumimos `1` nos próximos passos).
+
+### 4.3 Login do coordenador (captura `$TOKEN_COORD`)
+
+```bash
+TOKEN_COORD=$(curl -s -X POST http://localhost:8000/api/auth/login/ \
+  -H "Content-Type: application/json" \
+  -d '{"username": "coord1", "password": "senha123"}' \
+  | python3 -c "import sys, json; print(json.load(sys.stdin)['token'])")
+
+echo "TOKEN_COORD=$TOKEN_COORD"
+```
+
+Resposta bruta:
+
+```json
+{
+  "token": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+  "id": 1,
+  "tipo": "coordenador",
+  "nome": "Coord Eng"
+}
+```
+
+### 4.4 Coordenador aprova o processo (`PENDENTE → APROVADO`)
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/1/alterar_status/ \
+  -H "Authorization: Token $TOKEN_COORD" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "APROVADO"}' | python3 -m json.tool
+```
+
+Resposta esperada (`200 OK`) — retorna o processo completo atualizado:
+
+```json
+{
+  "id": 1,
+  "status": "APROVADO",
+  "aluno": 1,
+  "empresa": 1,
+  "coordenador": 1,
+  "horas_semanais": 20,
+  "data_inicio_prevista": "2026-07-01",
+  "data_fim_prevista": "2026-12-31",
+  "plano_atividades": "Desenvolvimento de APIs em Django.",
+  "justificativa_rejeicao": ""
+}
+```
+
+### 4.5 Coordenador ativa o processo (`APROVADO → ATIVO`)
+
+Quando o aluno efetivamente começa o estágio, o coordenador muda o status para `ATIVO`.
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/1/alterar_status/ \
+  -H "Authorization: Token $TOKEN_COORD" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "ATIVO"}' | python3 -m json.tool
+```
+
+Resposta (`200 OK`):
+
+```json
+{
+  "id": 1,
+  "status": "ATIVO",
+  "aluno": 1,
+  "empresa": 1,
+  "coordenador": 1,
+  "horas_semanais": 20
+}
+```
+
+### 4.6 Coordenador encerra o processo (`ATIVO → ENCERRADO`)
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/1/alterar_status/ \
+  -H "Authorization: Token $TOKEN_COORD" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "ENCERRADO"}' | python3 -m json.tool
+```
+
+Resposta (`200 OK`):
+
+```json
+{
+  "id": 1,
+  "status": "ENCERRADO",
+  "aluno": 1,
+  "empresa": 1,
+  "coordenador": 1
+}
+```
+
+`ENCERRADO` é um estado terminal — não há transições válidas a partir dele.
+
+## Walkthrough 2 — Cenários de erro (regras de negócio)
+
+Cada subseção dispara propositalmente uma regra de negócio para mostrar a resposta de erro. Reset o banco (seção 9) entre os walkthroughs 1 e 2 se quiser começar limpo, ou simplesmente cancele o processo criado antes de rodar os cenários de criação.
+
+### 5.1 Aluno não matriculado tenta criar (RN01)
+
+```bash
+TOKEN_ALUNO2=$(curl -s -X POST http://localhost:8000/api/auth/login/ \
+  -H "Content-Type: application/json" \
+  -d '{"username": "aluno2", "password": "senha123"}' \
+  | python3 -c "import sys, json; print(json.load(sys.stdin)['token'])")
+
+curl -s -X POST http://localhost:8000/api/processos-estagio/ \
+  -H "Authorization: Token $TOKEN_ALUNO2" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "empresa": 1,
+    "horas_semanais": 20,
+    "data_inicio_prevista": "2026-07-01",
+    "data_fim_prevista": "2026-12-31",
+    "plano_atividades": "Teste."
+  }' | python3 -m json.tool
+```
+
+Resposta (`400 Bad Request`):
+
+```json
+{
+  "aluno": [
+    "RN01: aluno deve estar com matrícula ativa em estágio supervisionado."
+  ]
+}
+```
+
+### 5.2 Empresa não aprovada (RN09)
+
+Usa o aluno1 (matriculado), mas aponta para a empresa não aprovada (`empresa=2`).
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/ \
+  -H "Authorization: Token $TOKEN_ALUNO" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "empresa": 2,
+    "horas_semanais": 20,
+    "data_inicio_prevista": "2026-07-01",
+    "data_fim_prevista": "2026-12-31",
+    "plano_atividades": "Teste empresa não aprovada."
+  }' | python3 -m json.tool
+```
+
+Resposta (`400 Bad Request`):
+
+```json
+{
+  "empresa": [
+    "RN09: empresa não está aprovada pelo IBMEC."
+  ]
+}
+```
+
+### 5.3 Horas semanais acima do limite do curso (RN03)
+
+O curso Eng. Software tem `carga_horaria_maxima_diaria=6`, logo o limite semanal é `6 × 5 = 30h`. Envie `40h`:
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/ \
+  -H "Authorization: Token $TOKEN_ALUNO" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "empresa": 1,
+    "horas_semanais": 40,
+    "data_inicio_prevista": "2026-07-01",
+    "data_fim_prevista": "2026-12-31",
+    "plano_atividades": "Teste excesso de horas."
+  }' | python3 -m json.tool
+```
+
+Resposta (`400 Bad Request`):
+
+```json
+{
+  "horas_semanais": [
+    "RN03: excede o limite do curso (30h/semana)."
+  ]
+}
+```
+
+### 5.4 Horas acima do limite legal (Lei 11.788/08)
+
+Mesmo se o curso permitisse, a Lei 11.788/08 fixa o teto em 30h semanais. Envie `35h` (que não dispara RN03 nesse curso porque o curso tem o mesmo limite, mas em cursos com limite maior dispararia a regra legal):
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/ \
+  -H "Authorization: Token $TOKEN_ALUNO" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "empresa": 1,
+    "horas_semanais": 35,
+    "data_inicio_prevista": "2026-07-01",
+    "data_fim_prevista": "2026-12-31",
+    "plano_atividades": "Teste limite legal."
+  }' | python3 -m json.tool
+```
+
+Resposta (`400 Bad Request`):
+
+```json
+{
+  "horas_semanais": [
+    "RN03: excede o limite do curso (30h/semana)."
+  ]
+}
+```
+
+Quando o limite do curso é maior que 30h, a mensagem retornada será `"Limite legal de 30h semanais (Lei 11.788/08)."`.
+
+### 5.5 Data fim anterior à data início
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/ \
+  -H "Authorization: Token $TOKEN_ALUNO" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "empresa": 1,
+    "horas_semanais": 20,
+    "data_inicio_prevista": "2026-07-01",
+    "data_fim_prevista": "2026-06-01",
+    "plano_atividades": "Teste data inválida."
+  }' | python3 -m json.tool
+```
+
+Resposta (`400 Bad Request`):
+
+```json
+{
+  "data_fim_prevista": [
+    "Deve ser posterior à data de início."
+  ]
+}
+```
+
+### 5.6 Aluno já tem processo vivo (RN05)
+
+Crie um processo válido primeiro (ver 4.2). Em seguida, tente criar outro:
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/ \
+  -H "Authorization: Token $TOKEN_ALUNO" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "empresa": 1,
+    "horas_semanais": 20,
+    "data_inicio_prevista": "2027-01-01",
+    "data_fim_prevista": "2027-06-30",
+    "plano_atividades": "Segundo processo."
+  }' | python3 -m json.tool
+```
+
+Resposta (`400 Bad Request`):
+
+```json
+{
+  "non_field_errors": [
+    "RN05: aluno já possui um processo de estágio em andamento. Cancele ou aguarde o encerramento antes de abrir outro."
+  ]
+}
+```
+
+### 5.7 Coordenador rejeita sem justificativa (RN11)
+
+Assume um processo `PENDENTE` com `id=1`. A rejeição exige `justificativa_rejeicao` não vazia.
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/1/alterar_status/ \
+  -H "Authorization: Token $TOKEN_COORD" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "REJEITADO"}' | python3 -m json.tool
+```
+
+Resposta (`400 Bad Request`):
+
+```json
+{
+  "justificativa_rejeicao": [
+    "RN11: justificativa obrigatória ao rejeitar uma solicitação."
+  ]
+}
+```
+
+### 5.8 Coordenador rejeita com justificativa válida
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/1/alterar_status/ \
+  -H "Authorization: Token $TOKEN_COORD" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "status": "REJEITADO",
+    "justificativa_rejeicao": "Plano de atividades incompatível com o curso."
+  }' | python3 -m json.tool
+```
+
+Resposta (`200 OK`):
+
+```json
+{
+  "id": 1,
+  "status": "REJEITADO",
+  "justificativa_rejeicao": "Plano de atividades incompatível com o curso.",
+  "aluno": 1,
+  "empresa": 1,
+  "coordenador": 1
+}
+```
+
+### 5.9 Transição inválida (`REJEITADO → ATIVO`)
+
+`REJEITADO` é estado terminal. Qualquer tentativa de transição é bloqueada com o conjunto `transicoes_validas` vazio.
+
+```bash
+curl -s -X POST http://localhost:8000/api/processos-estagio/1/alterar_status/ \
+  -H "Authorization: Token $TOKEN_COORD" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "ATIVO"}' | python3 -m json.tool
+```
+
+Resposta (`400 Bad Request`):
+
+```json
+{
+  "status": "Transição inválida: REJEITADO → ATIVO.",
+  "estado_atual": "REJEITADO",
+  "transicoes_validas": []
+}
+```
+
+## Walkthrough 3 — Isolamento por papel
+
+A API filtra o queryset de cada endpoint pelo papel do usuário autenticado. Os exemplos abaixo demonstram esse isolamento.
+
+### 6.1 Aluno1 lista — vê só os próprios processos
+
+```bash
+curl -s -X GET http://localhost:8000/api/processos-estagio/ \
+  -H "Authorization: Token $TOKEN_ALUNO" | python3 -m json.tool
+```
+
+Resposta (`200 OK`) — apenas processos cujo `aluno` é o aluno1:
+
+```json
+[
+  {
+    "id": 1,
+    "status": "PENDENTE",
+    "aluno": 1,
+    "empresa": 1,
+    "coordenador": 1,
+    "horas_semanais": 20
+  }
+]
+```
+
+### 6.2 Coordenador lista — vê só processos dos cursos dele
+
+```bash
+curl -s -X GET http://localhost:8000/api/processos-estagio/ \
+  -H "Authorization: Token $TOKEN_COORD" | python3 -m json.tool
+```
+
+Resposta (`200 OK`) — todos os processos cujo `aluno.curso.coordenador` é o coord1:
+
+```json
+[
+  {
+    "id": 1,
+    "status": "PENDENTE",
+    "aluno": 1,
+    "empresa": 1,
+    "coordenador": 1
+  }
+]
+```
+
+Se houver alunos em outros cursos com outros coordenadores, esses processos não aparecem aqui.
+
+### 6.3 Aluno1 tenta alterar processo do aluno2
+
+Crie um processo do aluno2 manualmente (via shell) ou matricule-o e crie via API. Em seguida, tente alterar pelo aluno1:
+
+```bash
+curl -s -o /dev/null -w "HTTP %{http_code}\n" \
+  -X POST http://localhost:8000/api/processos-estagio/2/alterar_status/ \
+  -H "Authorization: Token $TOKEN_ALUNO" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "CANCELADO"}'
+```
+
+Resposta esperada:
+
+```
+HTTP 404
+```
+
+A API retorna `404 Not Found` porque o queryset filtrado do aluno1 não inclui o processo do aluno2 — do ponto de vista dele, o recurso não existe. Caso o processo esteja em escopo mas a ação não seja permitida, a resposta seria `403 Forbidden` com:
+
+```json
+{
+  "detail": "Sem permissão neste processo."
+}
+```
+
+### 6.4 Coordenador de outro curso tenta aprovar
+
+Cenário coberto pelos testes em `app/tests.py::AlterarStatusTest::test_coord_de_outro_curso_403`. Se um coordenador de outro departamento tenta aprovar um processo cujo aluno não pertence aos seus cursos, a API responde:
+
+```json
+{
+  "detail": "Processo não pertence a curso sob sua coordenação."
+}
+```
+
+Status `403 Forbidden`. Esse cenário não é reproduzido neste walkthrough porque o seed só cria um coordenador — para reproduzi-lo, adicione um segundo coordenador e um segundo curso no shell.
+
+## Via Swagger UI
+
+Tudo o que foi demonstrado via `curl` pode ser feito pela interface gráfica do Swagger.
+
+1. Abra `http://localhost:8000/api/docs/` no navegador.
+2. Faça login (ou pegue um token via 4.1/4.3) e clique em **Authorize** no canto superior direito.
+3. No campo do esquema `tokenAuth`, digite `Token <seu_token>` — atenção: a palavra é literalmente `Token` (com T maiúsculo) seguida de espaço e o valor do token. Não use `Bearer`.
+4. Expanda qualquer endpoint, clique em **Try it out**, edite o JSON do body se necessário e clique em **Execute**. O Swagger mostra o `curl` equivalente, o status code e o JSON de resposta.
+5. Para trocar de usuário (por exemplo, de aluno para coordenador), clique em **Authorize** novamente, use **Logout** no esquema atual e cole o token do outro usuário.
+
+Vale notar que o Swagger UI suporta todos os endpoints documentados — incluindo `/api/auth/login/`, `/api/processos-estagio/`, `/api/processos-estagio/{id}/alterar_status/`, `/api/processos-estagio/{id}/documentos/` etc. Se preferir um ambiente totalmente clicável para explorar a API, use-o.
+
+## Via httpie (alternativa mais legível)
+
+`httpie` é uma alternativa moderna ao `curl` com saída colorida e sintaxe mais sucinta. Não está no `requirements.txt` do projeto — instale separadamente com `pip install httpie`.
+
+Login:
+
+```bash
+http POST :8000/api/auth/login/ \
+  username=aluno1 password=senha123
+```
+
+Criar processo (após capturar `$TOKEN`):
+
+```bash
+http POST :8000/api/processos-estagio/ \
+  "Authorization:Token $TOKEN" \
+  empresa:=1 \
+  horas_semanais:=20 \
+  data_inicio_prevista=2026-07-01 \
+  data_fim_prevista=2026-12-31 \
+  plano_atividades="APIs em Django"
+```
+
+Alterar status:
+
+```bash
+http POST :8000/api/processos-estagio/1/alterar_status/ \
+  "Authorization:Token $TOKEN_COORD" \
+  status=APROVADO
+```
+
+Os campos com `:=` são tratados como JSON nativo (números, booleanos, listas); os com `=` viram strings. Não esqueça das aspas em `"Authorization:Token $TOKEN"` — sem elas, o shell pode interpretar o `:` de forma errada.
+
+## Reset do banco (se precisar começar do zero)
+
+Se algum walkthrough deixou o banco em estado inconsistente, apague o SQLite e refaça migrations + seed:
+
+```bash
+rm djangotutorial/db.sqlite3
+uv run python djangotutorial/manage.py migrate
+uv run python djangotutorial/manage.py createsuperuser \
+    --username admin --email admin@ibmec.edu.br
+# Rode novamente o bloco de seed da seção 3
+```
+
+O `migrate` recria todas as tabelas. O `createsuperuser` pedirá a senha interativamente. Depois rode novamente o bloco de seed da seção 3 para repopular o banco com os usuários e cursos usados nos exemplos.
+
+## Autor(es)
+
+| Data | Versão | Descrição | Autor(es) |
+| -- | -- | -- | -- |
+| 28/05/2026 | 1.0 | Criação do documento | João Gabriel Teodósio |

--- a/docs/Construcao/api/index.md
+++ b/docs/Construcao/api/index.md
@@ -1,0 +1,157 @@
+# API IBMEC Estágios — Visão Geral
+
+A API IBMEC Estágios é o back-end REST que sustenta o Sistema de Gestão e Mediação de Estágios Obrigatórios do IBMEC. Construída em Django + Django REST Framework, ela expõe os recursos necessários para que alunos, coordenadores, supervisores de empresa e administradores conduzam todo o ciclo de vida do estágio obrigatório — da abertura da solicitação ao encerramento — com regras de negócio acadêmicas centralizadas, controle de acesso por papel e documentação OpenAPI gerada automaticamente a partir do código.
+
+## Stack tecnológica
+
+| Componente | Versão | Função no projeto |
+| -- | -- | -- |
+| Python | 3.13 | Linguagem base do back-end |
+| Django | 4.2.30 LTS | Framework web, ORM e administração |
+| djangorestframework | 3.16.1 | Camada REST (ViewSets, Serializers, Routers, Token Auth) |
+| drf-spectacular | 0.29.0 | Geração de schema OpenAPI 3 e Swagger/Redoc |
+| django-allauth | 65.14.3 | Suporte futuro a login social/institucional |
+| SQLite | embarcado | Banco de desenvolvimento local |
+| MySQL | 8.x | Banco relacional alvo em produção (definido no DAS) |
+
+## Arquitetura em camadas
+
+O fluxo de uma requisição HTTP percorre uma sequência clara de camadas, cada uma com responsabilidade única:
+
+```text
++--------------------------------------------------------------+
+|                      Cliente HTTP                            |
+|   (Swagger UI, Postman, front-end React, scripts)            |
++--------------------------------------------------------------+
+                              |
+                              v
++--------------------------------------------------------------+
+|       Routing — djangotutorial/app/api_urls.py               |
+|   DefaultRouter registra os 7 ViewSets + 3 endpoints auth    |
++--------------------------------------------------------------+
+                              |
+                              v
++--------------------------------------------------------------+
+|       Permissions — djangotutorial/app/permissions.py        |
+|   IsAuthenticated, IsAdminOrReadOnly, IsAluno,               |
+|   IsCoordenador, IsSupervisorEmpresa, IsDonoDoProcesso       |
++--------------------------------------------------------------+
+                              |
+                              v
++--------------------------------------------------------------+
+|       ViewSet — djangotutorial/app/views.py                  |
+|   get_queryset() filtra por papel; @action customiza ações;  |
+|   perform_create() injeta dono/coordenador automaticamente   |
++--------------------------------------------------------------+
+                              |
+              +---------------+---------------+
+              v                               v
++----------------------------+   +------------------------------+
+|  Serializer (DRF)          |   |  State Machine               |
+|  app/serializers.py        |   |  app/state_machine.py        |
+|  Valida payload, expõe DTO |   |  Mapa puro de transições     |
++----------------------------+   +------------------------------+
+              |                               |
+              +---------------+---------------+
+                              v
++--------------------------------------------------------------+
+|       Models / ORM — djangotutorial/app/models.py            |
+|   Usuario, Curso, EmpresaConcedente, Aluno, Coordenador,     |
+|   SupervisorEmpresa, ProcessoEstagio, DocumentoProcesso      |
++--------------------------------------------------------------+
+                              |
+                              v
++--------------------------------------------------------------+
+|       Banco de dados (SQLite em dev, MySQL em produção)      |
++--------------------------------------------------------------+
+```
+
+- **Cliente HTTP** — qualquer consumidor que fale JSON sobre HTTP. Durante o desenvolvimento, o Swagger UI hospedado pelo próprio Django já cobre a maioria dos testes manuais.
+- **Routing** — o `DefaultRouter` do DRF traduz URLs em ações de ViewSet (`list`, `retrieve`, `create`, `update`, `destroy`) e expõe `@action` extras como `alterar_status` e `documentos`.
+- **Permissions** — antes de qualquer linha de lógica rodar, as classes de permissão garantem que o usuário está autenticado e que tem o papel adequado para o método HTTP solicitado.
+- **ViewSet** — orquestra a operação. Filtra o queryset conforme o papel (RBAC implícito no `get_queryset`), escolhe o serializer adequado e injeta campos derivados em `perform_create`.
+- **Serializer** — atua como DTO de entrada e saída: valida campos, aplica regras de negócio declarativas (ex.: justificativa obrigatória ao rejeitar, RN11) e serializa modelos em JSON.
+- **State Machine** — módulo Python puro com o mapa de transições válidas. Não conhece Django; é importado pelo ViewSet/Serializer para garantir que mudanças de status sigam o fluxo desenhado.
+- **Models / ORM** — define as entidades persistentes e os relacionamentos. O ORM do Django funciona como um repositório implícito.
+- **Banco de dados** — SQLite em desenvolvimento local; o DAS prevê MySQL relacional em produção.
+
+## Padrões aplicados
+
+1. **MVT (Model–View–Template) adaptado para API** — variação Django do MVC clássico. A camada de "Template" é substituída pelo Serializer, que transforma os Models em representações JSON consumidas pelos clientes.
+2. **DTO via Serializers DRF** — cada recurso tem um serializer dedicado (`ProcessoEstagioSerializer`, `CriarProcessoSerializer`, `AlterarStatusSerializer`) que define explicitamente os campos expostos, isolando o modelo de domínio do contrato externo.
+3. **State Machine pattern** — o módulo `state_machine.py` mantém o mapa de transições válidas como dado puro. O ViewSet consulta `transicoes_validas(status_atual)` antes de qualquer mudança, evitando estados ilegais.
+4. **RBAC (Role-Based Access Control)** — quatro papéis (`aluno`, `coordenador`, `supervisor_empresa`, `admin`) determinam o que cada usuário vê e pode fazer. As classes em `permissions.py` e os filtros em `get_queryset` aplicam essa política em toda chamada.
+5. **Repository implícito via ORM do Django** — em vez de uma camada de repositório explícita, o `QuerySet` do Django atua como repositório, com `select_related` reduzindo o N+1 nas leituras compostas.
+6. **Defensive programming (fail-fast, negação por default)** — quando o `get_queryset` não consegue identificar o papel do usuário, o retorno é `.none()` em vez de `.all()`. Em caso de dúvida, a API nega o acesso.
+7. **Separation of Concerns** — modelagem fica em `models.py`, validação em `serializers.py`, autorização em `permissions.py`, orquestração em `views.py` e regras de transição em `state_machine.py`. Cada arquivo tem um motivo único para mudar.
+
+## Documentação automática
+
+A API descreve a si mesma graças ao `drf-spectacular`. Três endpoints são gerados automaticamente a partir dos ViewSets, Serializers e docstrings do código — não há schema mantido à mão:
+
+| Endpoint | O que entrega |
+| -- | -- |
+| `/api/docs/` | Swagger UI interativo — explorar e testar requisições direto do navegador |
+| `/api/redoc/` | Redoc — leitura linear, ótimo para consumo por terceiros |
+| `/api/schema/` | JSON OpenAPI 3 bruto — fonte para gerar clientes em outras linguagens |
+
+Sempre que um campo de serializer ou uma docstring de ViewSet muda, os três endpoints refletem a alteração no próximo request. **A documentação interativa é a fonte de verdade dos schemas**; este conjunto de Markdown explica o "porquê" e o "como", não substitui o Swagger.
+
+## Convenções da API
+
+Algumas convenções valem para todos os recursos e ajudam a entender as respostas:
+
+- **Formato** — todos os corpos de requisição e resposta usam JSON com `Content-Type: application/json`. Uploads de arquivo usam `multipart/form-data`.
+- **Autenticação** — token DRF no header `Authorization: Token <chave>`. Sem token, qualquer rota protegida responde `401 Unauthorized`.
+- **Datas** — formato ISO 8601 (`YYYY-MM-DD` para datas simples, `YYYY-MM-DDTHH:MM:SSZ` para timestamps em UTC).
+- **Paginação** — listagens seguem o padrão DRF com `count`, `next`, `previous` e `results`. O cliente passa `?page=N` para navegar.
+- **Status codes** — `200` para leitura, `201` para criação, `204` para `DELETE`, `400` para erro de validação, `401` sem auth, `403` sem papel, `404` quando o recurso não está visível ao usuário.
+- **Identificadores** — todos os recursos usam `id` numérico autoincrementado pelo banco.
+
+## Status atual da entrega
+
+Esta documentação acompanha a PR [#47](https://github.com/Projetos-de-Extensao/PBE_26.1_8002_I/pull/47), que fecha a issue [#46](https://github.com/Projetos-de-Extensao/PBE_26.1_8002_I/issues/46) e entrega a fatia vertical da Pessoa 1 (núcleo do `ProcessoEstagio`).
+
+Pronto nesta entrega:
+
+- Modelos completos das 8 entidades (`Usuario`, `Curso`, `EmpresaConcedente`, `Aluno`, `Coordenador`, `SupervisorEmpresa`, `ProcessoEstagio`, `DocumentoProcesso`).
+- Autenticação por token DRF com 3 endpoints (`register`, `login`, `logout`) e três tipos de cadastro.
+- 7 ViewSets ModelViewSet expostos via `DefaultRouter`, com filtros por papel em `get_queryset`.
+- Máquina de estados pura cobrindo 8 status e suas transições válidas.
+- Action `POST /api/processos-estagio/{id}/alterar_status/` validando transição + papel + justificativa.
+- Action `GET /api/processos-estagio/{id}/documentos/` listando documentos do processo.
+- Filtros de query string em `EmpresaConcedente` (`?aprovada=`, `?busca=`).
+- Swagger UI, Redoc e schema OpenAPI 3 servidos automaticamente.
+
+Fora do escopo (entregas seguintes — Pessoas 2 a 5): endpoints derivados do coordenador, perfis próprios do aluno/empresa, upload com validação MIME/tamanho e geração de TCE/Termo de Realização. A lista completa está em [Endpoints](endpoints.md#fora-do-escopo-desta-entrega).
+
+## Como rodar localmente
+
+Para subir a API em desenvolvimento, a partir da raiz do repositório:
+
+```bash
+cd djangotutorial
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python manage.py migrate
+python manage.py createsuperuser
+python manage.py runserver
+```
+
+Com o servidor de pé em `http://localhost:8000`, o Swagger UI fica em `http://localhost:8000/api/docs/` e o admin Django em `http://localhost:8000/admin/`. O banco SQLite (`db.sqlite3`) é criado automaticamente no primeiro `migrate`. Para popular o ambiente com dados de teste, use o admin Django ou rode o seed previsto no `manage.py` (em desenvolvimento conforme a issue de testes).
+
+## Navegação da subseção
+
+- [Autenticação](autenticacao.md) — fluxo de registro, login e uso do token DRF.
+- [Endpoints](endpoints.md) — referência tabular completa dos recursos REST.
+- [Regras de Negócio](regras-negocio.md) — onde cada RN está implementada no código.
+- [Máquina de Estados](state-machine.md) — diagrama e tabela das transições do `ProcessoEstagio`.
+- [Exemplos de Uso](exemplos.md) — fluxos completos com `curl` e payloads reais.
+- [Códigos de Erro](erros.md) — catálogo de respostas 4xx/5xx e como tratá-las.
+
+## Autor(es)
+
+| Data | Versão | Descrição | Autor(es) |
+| -- | -- | -- | -- |
+| 28/05/2026 | 1.0 | Criação do documento | João Gabriel Teodósio |

--- a/docs/Construcao/api/regras-negocio.md
+++ b/docs/Construcao/api/regras-negocio.md
@@ -1,0 +1,317 @@
+# Regras de Negócio — Rastreabilidade
+
+Este documento mapeia cada **regra de negócio** (RN) implementada na API IBMEC Estágios ao **código que a aplica** e ao **teste automatizado que prova seu funcionamento**. A filosofia é simples: toda RN levantada na fase de elaboração precisa virar código testado e auditável. Quem ler este documento deve conseguir, em poucos cliques, sair da redação da regra no documento de requisitos, chegar à linha exata do `serializers.py`/`views.py` que a executa e confirmar que existe um teste com nome explícito provando aquela regra. As regras estão na PR #47 (issue #46) e foram derivadas do documento `docs/Elaboracao/Requisitos/Requisitos-Gerais.md`, da Lei 11.788/08 e das normas internas do IBMEC.
+
+## Tabela mestre
+
+| ID   | Regra (resumo)                                       | Fonte normativa                | Onde é validada                          | Teste que prova                                          | HTTP |
+| ---- | ---------------------------------------------------- | ------------------------------ | ---------------------------------------- | -------------------------------------------------------- | ---- |
+| RN01 | Aluno deve estar matriculado em estágio supervisionado | Regulamento IBMEC + RF04       | `CriarProcessoSerializer.validate`       | `test_aluno_nao_matriculado_400_rn01`                    | 400  |
+| RN03 | Jornada compatível com a carga máxima do curso (PPC) | PPC do curso + Lei 11.788/08   | `CriarProcessoSerializer.validate`       | `test_horas_excedem_limite_curso_400_rn03`               | 400  |
+| RN05 | Um único processo "vivo" por aluno por vez           | Regulamento IBMEC              | `CriarProcessoSerializer.validate`       | `test_aluno_com_processo_vivo_nao_cria_outro_400_rn05`   | 400  |
+| RN09 | Empresa precisa estar aprovada pelo IBMEC            | Regulamento IBMEC              | `CriarProcessoSerializer.validate`       | `test_empresa_nao_aprovada_400_rn09`                     | 400  |
+| RN11 | Justificativa obrigatória em rejeição                | RF11 de `Requisitos-Gerais.md` | `AlterarStatusSerializer.validate`       | `test_coord_rejeita_sem_justificativa_400_rn11`          | 400  |
+| LEI  | Limite legal de 30h/semana                           | Lei 11.788/08 art. 10          | `CriarProcessoSerializer.validate`       | `test_horas_acima_limite_legal_30h_400`                  | 400  |
+| DATA | `data_fim_prevista > data_inicio_prevista`           | Validação básica de domínio    | `CriarProcessoSerializer.validate`       | `test_data_fim_antes_inicio_400`                         | 400  |
+
+Observação sobre nomenclatura: o documento `Requisitos-Gerais.md` lista o item de **justificativa obrigatória** como **RF11** (requisito funcional). No código, porém, ele aparece referenciado como `RN11` nas mensagens de erro e nos nomes dos testes, por convenção do time, já que se comporta como uma regra de validação de negócio. Este documento adota o nome **RN11** para manter consistência com o que aparece na API.
+
+## Detalhes por regra
+
+### RN01 — Aluno deve estar matriculado em estágio
+
+**O que diz.** "O sistema só deve permitir que o aluno realize login na plataforma se ele estiver devidamente matriculado na disciplina 'Estágio Supervisionado'." (`Requisitos-Gerais.md`, RN01.) A implementação atual aplica a regra **na criação do processo** (e não no login), pois o login está aberto a alunos em geral; o que está bloqueado é abrir solicitação de estágio sem matrícula ativa.
+
+**Por que existe.** Garante que apenas alunos com vínculo formal com a disciplina possam iniciar um processo de estágio. Evita estágios "fantasma" e protege a integridade acadêmica da supervisão.
+
+**Onde está implementada.** `djangotutorial/app/serializers.py`, classe `CriarProcessoSerializer`, método `validate`.
+
+```python
+# RN01: matriculado em estágio
+if not aluno.matriculado_estagio:
+    raise serializers.ValidationError({
+        'aluno': 'RN01: aluno deve estar com matrícula ativa em estágio supervisionado.'
+    })
+```
+
+**Teste que prova.** `test_aluno_nao_matriculado_400_rn01` em `djangotutorial/app/tests.py`, classe `CriacaoProcessoTest`. Usa o `aluno_nao_matriculado` (criado no `setUp` com `matriculado_estagio=False`) e tenta `POST /api/processos-estagio/`.
+
+**Resposta HTTP esperada.** `400 Bad Request`.
+
+```json
+{
+  "aluno": ["RN01: aluno deve estar com matrícula ativa em estágio supervisionado."]
+}
+```
+
+### RN03 — Jornada compatível com o curso
+
+**O que diz.** "O sistema deve impedir a aprovação do estágio caso a carga horária oferecida pela empresa seja incompatível com a quantidade mínima de horas exigida pelo curso do aluno." (`Requisitos-Gerais.md`, RN03.) A implementação aqui é o **teto** por curso: cada curso define `carga_horaria_maxima_diaria` no model `Curso`, e o limite semanal é calculado como `5 × diária`.
+
+**Por que existe.** O Projeto Pedagógico de cada curso define uma carga máxima compatível com a grade acadêmica. Engenharia, por exemplo, tem 6h/dia → 30h/semana no curso da base de testes. Aceitar mais do que isso comprometeria o desempenho acadêmico do aluno.
+
+**Onde está implementada.** `djangotutorial/app/serializers.py`, `CriarProcessoSerializer.validate`.
+
+```python
+# RN03: jornada compatível com o curso
+horas = data['horas_semanais']
+if aluno.curso is not None and aluno.curso.carga_horaria_maxima_diaria:
+    limite_curso = aluno.curso.carga_horaria_maxima_diaria * 5
+    if horas > limite_curso:
+        raise serializers.ValidationError({
+            'horas_semanais': f'RN03: excede o limite do curso ({limite_curso}h/semana).'
+        })
+```
+
+**Teste que prova.** `test_horas_excedem_limite_curso_400_rn03` em `tests.py`, classe `CriacaoProcessoTest`. Envia `horas_semanais=40` para um aluno cujo curso tem limite de 30.
+
+**Resposta HTTP esperada.** `400 Bad Request`.
+
+```json
+{
+  "horas_semanais": ["RN03: excede o limite do curso (30h/semana)."]
+}
+```
+
+### RN05 — Um processo "vivo" por aluno
+
+**O que diz.** "O sistema deve restringir e controlar o tempo máximo que um aluno pode estagiar em uma mesma empresa concedente." (`Requisitos-Gerais.md`, RN05.) A interpretação operacional para a entrega da PR #47 é mais conservadora: **enquanto houver um processo em estado vivo (`RASCUNHO`, `PENDENTE`, `APROVADO`, `CORRECAO_SOLICITADA` ou `ATIVO`) para o aluno, ele não pode abrir outro**.
+
+**Por que existe.** Evita que um aluno acumule múltiplas solicitações simultâneas, fazendo o coordenador escolher entre elas. Força o aluno a explicitamente **cancelar** o processo anterior (ou aguardar encerramento) antes de tentar de novo.
+
+**Onde está implementada.** `djangotutorial/app/serializers.py`, `CriarProcessoSerializer.validate`. O conjunto `ESTADOS_VIVOS` vem de `state_machine.py`.
+
+```python
+# RN05: 1 processo vivo por aluno
+if ProcessoEstagio.objects.filter(aluno=aluno, status__in=ESTADOS_VIVOS).exists():
+    raise serializers.ValidationError(
+        'RN05: aluno já possui um processo de estágio em andamento. '
+        'Cancele ou aguarde o encerramento antes de abrir outro.'
+    )
+```
+
+**Teste que prova.** `test_aluno_com_processo_vivo_nao_cria_outro_400_rn05` em `tests.py`, classe `CriacaoProcessoTest`. Cria um processo `PENDENTE` direto via ORM e depois tenta abrir um segundo via API.
+
+**Resposta HTTP esperada.** `400 Bad Request`.
+
+```json
+{
+  "non_field_errors": [
+    "RN05: aluno já possui um processo de estágio em andamento. Cancele ou aguarde o encerramento antes de abrir outro."
+  ]
+}
+```
+
+### RN09 — Empresa aprovada pelo IBMEC
+
+**O que diz.** "O aluno não pode prosseguir com a formalização do estágio em uma empresa que não tenha sido previamente aprovada/homologada pela faculdade no sistema." (`Requisitos-Gerais.md`, RN09.)
+
+**Por que existe.** Garante que apenas empresas previamente avaliadas e homologadas pelo IBMEC possam receber alunos. A homologação é manual (admin/coordenador via Django Admin) e fica registrada em `EmpresaConcedente.aprovada_ibmec=True`.
+
+**Onde está implementada.** `djangotutorial/app/serializers.py`, `CriarProcessoSerializer.validate`.
+
+```python
+# RN09: empresa aprovada pelo IBMEC
+empresa = data['empresa']
+if not empresa.aprovada_ibmec:
+    raise serializers.ValidationError({
+        'empresa': 'RN09: empresa não está aprovada pelo IBMEC.'
+    })
+```
+
+**Teste que prova.** `test_empresa_nao_aprovada_400_rn09` em `tests.py`, classe `CriacaoProcessoTest`. Usa `empresa_nao_aprovada` (criada no `setUp` com `aprovada_ibmec=False`).
+
+**Resposta HTTP esperada.** `400 Bad Request`.
+
+```json
+{
+  "empresa": ["RN09: empresa não está aprovada pelo IBMEC."]
+}
+```
+
+### LEI — Lei 11.788/08, art. 10 (30h/semana)
+
+**O que diz.** O art. 10 da Lei 11.788/08 fixa o **teto legal** de 30 horas semanais para estágio não-obrigatório de nível superior (4h/dia em casos especiais e 6h em casos gerais, somando no máximo 30h semanais). Veja `docs/Iniciacao/pesquisa-detalhes/legislacao_trabalhista.md`.
+
+**Por que existe.** Cumprimento de obrigação legal (RNF05 — Conformidade). Nenhum curso pode autorizar mais do que isso, ainda que o PPC interno permitisse mais — a Lei tem precedência.
+
+**Onde está implementada.** `djangotutorial/app/serializers.py`, `CriarProcessoSerializer.validate`, logo depois do bloco do RN03.
+
+```python
+# Ceiling legal (Lei 11.788/08)
+if horas > 30:
+    raise serializers.ValidationError({
+        'horas_semanais': 'Limite legal de 30h semanais (Lei 11.788/08).'
+    })
+```
+
+**Teste que prova.** `test_horas_acima_limite_legal_30h_400` em `tests.py`, classe `CriacaoProcessoTest`. Envia `horas_semanais=35`.
+
+**Resposta HTTP esperada.** `400 Bad Request`.
+
+```json
+{
+  "horas_semanais": ["Limite legal de 30h semanais (Lei 11.788/08)."]
+}
+```
+
+### DATA — `data_fim_prevista > data_inicio_prevista`
+
+**O que diz.** Validação básica de domínio: a data de término precisa ser **estritamente posterior** à data de início. Datas iguais também são rejeitadas, porque um estágio precisa ter duração maior que zero.
+
+**Por que existe.** Evita estados de domínio inválidos no banco. É a primeira validação executada no método `validate`, antes de qualquer regra que dependa do contexto da requisição.
+
+**Onde está implementada.** `djangotutorial/app/serializers.py`, `CriarProcessoSerializer.validate`.
+
+```python
+# Data: fim > início
+if data['data_fim_prevista'] <= data['data_inicio_prevista']:
+    raise serializers.ValidationError({
+        'data_fim_prevista': 'Deve ser posterior à data de início.'
+    })
+```
+
+**Teste que prova.** `test_data_fim_antes_inicio_400` em `tests.py`, classe `CriacaoProcessoTest`. Envia `data_inicio_prevista=2026-07-01` e `data_fim_prevista=2026-06-01`.
+
+**Resposta HTTP esperada.** `400 Bad Request`.
+
+```json
+{
+  "data_fim_prevista": ["Deve ser posterior à data de início."]
+}
+```
+
+### RN11 — Justificativa obrigatória em rejeição
+
+**O que diz.** "O sistema deve exigir justificativa em caso de rejeição." (`Requisitos-Gerais.md`, **RF11**, mapeado como RN11 no código.)
+
+**Por que existe.** Decisões negativas que afetam o aluno precisam ser registradas com motivação clara, tanto para fins acadêmicos (o aluno precisa saber o que corrigir) quanto para fins de auditoria (a coordenação fica obrigada a justificar suas decisões).
+
+**Onde está implementada.** `djangotutorial/app/serializers.py`, classe `AlterarStatusSerializer`, método `validate`. A validação só é disparada quando o `status` recebido é `REJEITADO`.
+
+```python
+def validate(self, data):
+    if data.get('status') == ProcessoEstagio.Status.REJEITADO:
+        justif = data.get(
+            'justificativa_rejeicao',
+            self.instance.justificativa_rejeicao if self.instance else '',
+        )
+        if not justif or not justif.strip():
+            raise serializers.ValidationError({
+                'justificativa_rejeicao': 'RN11: justificativa obrigatória ao rejeitar uma solicitação.'
+            })
+    return data
+```
+
+**Teste que prova.** `test_coord_rejeita_sem_justificativa_400_rn11` em `tests.py`, classe `AlterarStatusTest`. O coordenador autenticado envia `POST /api/processos-estagio/<id>/alterar_status/` com `{"status": "REJEITADO"}` sem `justificativa_rejeicao`.
+
+**Resposta HTTP esperada.** `400 Bad Request`.
+
+```json
+{
+  "justificativa_rejeicao": ["RN11: justificativa obrigatória ao rejeitar uma solicitação."]
+}
+```
+
+## Validação de transições de status (state machine)
+
+Não é uma "RN" do documento de requisitos, mas é uma regra **crítica de domínio**: o status de um processo só pode mudar seguindo o mapa de transições definido em `djangotutorial/app/state_machine.py`. Por exemplo, um processo em estado terminal (`REJEITADO`, `ENCERRADO`, `CANCELADO`) não pode mais transitar para nenhum outro estado.
+
+**Onde está implementada.** `djangotutorial/app/views.py`, `ProcessoEstagioViewSet.alterar_status`, passo 1, junto com `state_machine.transicoes_validas`:
+
+```python
+validas = transicoes_validas(processo.status)
+if novo_status not in validas:
+    return Response({
+        'status': f'Transição inválida: {processo.status} → {novo_status}.',
+        'estado_atual': processo.status,
+        'transicoes_validas': sorted(validas) if validas else [],
+    }, status=drf_status.HTTP_400_BAD_REQUEST)
+```
+
+**Teste que prova.** `test_transicao_invalida_400_lista_validas` em `tests.py`, classe `AlterarStatusTest`. Cria um processo já `REJEITADO` e tenta movê-lo para `ATIVO`.
+
+**Resposta HTTP esperada.** `400 Bad Request`, com `transicoes_validas` listando alternativas (vazio quando o estado atual é terminal).
+
+```json
+{
+  "status": "Transição inválida: REJEITADO → ATIVO.",
+  "estado_atual": "REJEITADO",
+  "transicoes_validas": []
+}
+```
+
+Veja [state-machine.md](state-machine.md) para o diagrama completo do fluxo e a tabela de transições válidas.
+
+## RBAC: permissão por papel
+
+Também não é uma "RN" listada nos requisitos, mas é uma regra **crítica de segurança**. A API impõe permissão por papel em duas camadas complementares:
+
+**1. Queryset filtrado por papel** (`ProcessoEstagioViewSet.get_queryset`). Cada papel só "enxerga" um subconjunto dos processos:
+
+- **Aluno** → apenas os próprios processos (`base.filter(aluno=aluno)`).
+- **Supervisor de empresa** → apenas processos da sua empresa (`base.filter(empresa=supervisor.empresa)`).
+- **Coordenador** → apenas processos de alunos dos cursos que coordena (`base.filter(aluno__curso__coordenador=coord)`).
+- **Admin (superuser)** → todos os processos.
+
+Isso significa que tentar acessar um processo "alheio" devolve **404** (o registro existe, mas o queryset do papel não o enxerga), e não 403 — defesa em profundidade por filtro.
+
+**2. Validação de quem dispara qual transição** (`ProcessoEstagioViewSet.alterar_status`, passo 2). Após confirmar que a transição é válida no mapa de estados, a view checa **quem pode dispará-la**:
+
+- **Aluno**: só pode `RASCUNHO → PENDENTE` (submeter) ou `* → CANCELADO` (cancelar) **no próprio processo**.
+- **Coordenador**: pode disparar `APROVADO`, `REJEITADO`, `CORRECAO_SOLICITADA`, `ATIVO` e `ENCERRADO`, e apenas em processos de alunos dos cursos que coordena.
+- **Admin**: pode disparar qualquer transição válida.
+
+Violações desse contrato retornam **403 Forbidden** com `{"detail": "..."}`.
+
+**Testes que provam.**
+
+| Teste                                                | Classe                  | Verifica                                                                                  |
+| ---------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------- |
+| `test_aluno_lista_apenas_proprios`                   | `IsolamentoQuerysetTest`| Aluno só vê seus processos no `GET /api/processos-estagio/`.                              |
+| `test_supervisor_lista_apenas_empresa_dele`          | `IsolamentoQuerysetTest`| Supervisor só vê processos da própria empresa.                                            |
+| `test_coordenador_lista_apenas_cursos_dele`          | `IsolamentoQuerysetTest`| Coordenador só vê processos de alunos dos cursos que coordena.                            |
+| `test_admin_lista_todos`                             | `IsolamentoQuerysetTest`| Admin vê todos os processos.                                                              |
+| `test_aluno_nao_pode_alterar_processo_de_outro_403`  | `AlterarStatusTest`     | Aluno tentando mexer em processo de outro aluno → 403 ou 404.                             |
+| `test_coord_de_outro_curso_403`                      | `AlterarStatusTest`     | Coordenador de outro curso tentando aprovar → 403 ou 404.                                 |
+| `test_aluno_nao_pode_aprovar_proprio_400_ou_403`     | `AlterarStatusTest`     | Aluno tentando aprovar o próprio processo → 400 ou 403.                                   |
+
+**Resposta HTTP esperada.** `403 Forbidden` quando a permission detecta a violação após a view recuperar o objeto; `404 Not Found` quando o queryset do papel já tinha filtrado o objeto antes (por isso vários testes aceitam ambos os códigos).
+
+Veja a seção [Resumo de permissões por papel](endpoints.md#resumo-de-permissoes-por-papel) em `endpoints.md` para a matriz papel × verbo completa.
+
+## Cobertura de testes
+
+Total: **24 testes** em **4 classes**, organizados em `djangotutorial/app/tests.py`:
+
+| Classe                     | # testes | Foco                                                                            |
+| -------------------------- | -------- | ------------------------------------------------------------------------------- |
+| `CriacaoProcessoTest`      | 8        | POST `/api/processos-estagio/`: RN01, RN03, RN05, RN09, LEI 30h, DATA, autenticação. |
+| `IsolamentoQuerysetTest`   | 4        | GET `/api/processos-estagio/`: filtragem por papel (aluno, supervisor, coord, admin). |
+| `AlterarStatusTest`        | 8        | POST `/api/processos-estagio/<id>/alterar_status/`: transições, RN11, RBAC.     |
+| `StateMachineUnitTest`     | 4        | Unit tests puros do módulo `app.state_machine`.                                 |
+
+Convenção dos nomes: sempre que o teste cobre uma regra com ID, o ID aparece no nome (`_rn01`, `_rn03`, `_rn05`, `_rn09`, `_rn11`). Isso garante rastreabilidade bidirecional: do código pro teste, e do teste pro requisito. Rodar a suíte:
+
+```bash
+cd djangotutorial
+../.venv/bin/python manage.py test app -v 2
+```
+
+## Regras NÃO implementadas (fora do escopo desta entrega)
+
+A PR #47 cobre o núcleo de validações que travam o pipeline básico do processo. Os RNs/RFs abaixo continuam no backlog e ficam como follow-up para próximas entregas:
+
+- **RN02 — Pré-requisitos acadêmicos do PPC.** Hoje só validamos `matriculado_estagio`. Validar disciplinas concluídas, CR mínimo e período mínimo exige um motor de regras por curso (provavelmente um JSON no `Curso` ou um app dedicado). Fica como follow-up.
+- **RN04 — Jornada diária + semanal combinadas.** O limite **legal** semanal (30h) já está; falta validar a jornada **diária** declarada e cruzá-la com o `carga_horaria_maxima_diaria` do curso. Hoje aceitamos só `horas_semanais` no payload. Fica como follow-up junto com o redesenho do payload.
+- **RN06 — Bloqueio de aprovação sem TCE + apólice de seguro.** Depende dos models de documento e do fluxo de upload (`Pessoa 5`). Fica como follow-up — quando aterrissar, vira mais uma checagem no `AlterarStatusSerializer.validate` no caso `status=APROVADO`.
+- **RN07 — Validação automática de área de atuação vs. curso.** Requer NLP/análise textual do `plano_atividades` ou taxonomia formal de áreas no `Curso`. Fica como follow-up de longo prazo (ligado a RF08 — análise automatizada).
+- **RN08 — Notificações de atraso de relatórios.** Pré-requisito: model de relatório obrigatório + scheduler (Celery/cron). Não há infra de jobs ainda. Fica como follow-up.
+- **RN10 — Campos obrigatórios da empresa.** Parcialmente coberto: `EmpresaConcedente` exige `cnpj`, `razao_social`, `areas_atuacao` e `localizacao` no model (constraint de banco). Falta uma validação explícita no `EmpresaConcedenteSerializer` com mensagens de erro padronizadas. Fica como follow-up.
+- **RF18 — Abertura formal por escolha de vaga.** Parcialmente coberto: hoje o aluno descreve a oportunidade no `plano_atividades`, sem model `Vaga`. Quando entrar o catálogo de vagas, o `CriarProcessoSerializer` recebe `vaga_id` e a validação passa a vincular processo a vaga. Fica como follow-up.
+
+## Autor(es)
+
+| Data       | Versão | Descrição              | Autor(es)               |
+| ---------- | ------ | ---------------------- | ----------------------- |
+| 28/05/2026 | 1.0    | Criação do documento   | João Gabriel Teodósio   |

--- a/docs/Construcao/api/state-machine.md
+++ b/docs/Construcao/api/state-machine.md
@@ -1,0 +1,199 @@
+# Máquina de Estados de `ProcessoEstagio`
+
+Uma **máquina de estados finita** descreve um sistema cuja evolução é restrita a um conjunto fechado de situações (estados) e a regras claras de transição entre elas. Em cada momento, a entidade está em exatamente um estado, e só pode passar a outro se a transição estiver explicitamente declarada como válida.
+
+`ProcessoEstagio` é o agregado central da API IBMEC Estágios e precisa de uma máquina de estados porque seu ciclo de vida envolve múltiplos atores (aluno, coordenador, admin), decisões irreversíveis (aprovação, rejeição, encerramento) e regras de negócio que dependem do estado atual. Codificar essas regras em um módulo dedicado evita estados inconsistentes, transições proibidas silenciosas e duplicação de lógica entre views, serializers e admin.
+
+## Por que módulo Python puro
+
+A máquina vive em `djangotutorial/app/state_machine.py` como um módulo **Python puro**: sem `import django`, sem ORM, sem dependência de request. Essa escolha traz três ganhos diretos:
+
+- **Testabilidade isolada:** o módulo pode ser exercitado com `pytest`/`unittest` sem subir banco, sem fixtures, sem `setUp` de modelos. A suíte `StateMachineUnitTest` em `app/tests.py` valida transições em milissegundos.
+- **Reusabilidade:** as mesmas constantes e funções são consumidas pela view (`ProcessoEstagioViewSet.alterar_status`), pelos serializers de validação, pelo admin e, no futuro, por jobs assíncronos ou comandos de manage.
+- **Separação de concerns:** a regra "pode ir de X para Y?" é uma propriedade do domínio, não da camada web. Mantê-la fora de `views.py` deixa o fluxo HTTP responsável apenas por orquestração e resposta.
+
+As constantes string em `state_machine.py` casam exatamente com `ProcessoEstagio.Status.values` em `app/models.py` — isso é contrato, não coincidência.
+
+## Os 8 estados
+
+| Estado | Descrição | É terminal? |
+| --- | --- | --- |
+| `RASCUNHO` | "Salvar para depois". Reservado para feature futura; hoje o processo nasce em `PENDENTE` | não |
+| `PENDENTE` | Submetido; aguarda análise do coordenador | não |
+| `APROVADO` | Coordenador aprovou; aguarda o início efetivo do estágio | não |
+| `ATIVO` | Estágio em execução, com documentos formalizados e jornada vigente | não |
+| `ENCERRADO` | Estágio concluído após relatório final e validação | sim |
+| `REJEITADO` | Coordenador rejeitou; exige justificativa | sim |
+| `CORRECAO_SOLICITADA` | Coordenador pediu ajustes; aluno deve reenviar para `PENDENTE` | não |
+| `CANCELADO` | Cancelamento por aluno, coordenador ou admin em qualquer ponto do ciclo | sim |
+
+Estados terminais não admitem nenhuma transição de saída — uma vez ali, o processo é histórico. Para o aluno tentar de novo, é necessário **abrir um novo processo**, com novo `pk`. Essa decisão de modelagem preserva a rastreabilidade: cada `ProcessoEstagio` é um registro imutável após chegar a um terminal, e o histórico do aluno é reconstruído pela coleção dos processos passados.
+
+`CANCELADO` aparece como destino possível em **todos** os estados vivos por uma razão de produto: um estágio pode ser interrompido por motivos institucionais a qualquer momento, e cancelar nunca deve estar bloqueado por validação de transição. Já `REJEITADO` e `ENCERRADO` são terminais semanticamente diferentes — o primeiro indica que o estágio nunca aconteceu, o segundo indica que aconteceu e foi finalizado com sucesso.
+
+## Diagrama de transições
+
+```puml
+@startuml
+left to right direction
+skinparam state {
+  BackgroundColor White
+  BorderColor Black
+}
+[*] --> PENDENTE : criar
+PENDENTE --> APROVADO
+PENDENTE --> REJEITADO
+PENDENTE --> CORRECAO_SOLICITADA
+PENDENTE --> CANCELADO
+APROVADO --> ATIVO
+APROVADO --> CANCELADO
+CORRECAO_SOLICITADA --> PENDENTE
+CORRECAO_SOLICITADA --> CANCELADO
+ATIVO --> ENCERRADO
+ATIVO --> CANCELADO
+RASCUNHO --> PENDENTE
+RASCUNHO --> CANCELADO
+REJEITADO --> [*]
+ENCERRADO --> [*]
+CANCELADO --> [*]
+@enduml
+```
+
+A entrada `[*] --> PENDENTE` mostra que, na prática, o processo nasce já submetido. `RASCUNHO` aparece no diagrama por completude da modelagem, mas hoje não é alvo de `perform_create`: a view força `status=PENDENTE` no momento da criação, e a transição `RASCUNHO → PENDENTE` só passa a ser exercitada quando a feature de "salvar para depois" for implementada (issue futura).
+
+Convenções gráficas do diagrama:
+
+- Cada nó corresponde a uma constante string em `state_machine.py`.
+- Setas representam transições válidas declaradas em `TRANSICOES`.
+- `[*]` no início indica o ponto de criação; `[*]` no final indica que o estado é terminal.
+
+## Tabela "De → Para permitido"
+
+Cópia literal do dicionário `TRANSICOES` em `state_machine.py`. A coluna da esquerda é o estado atual; a da direita, o conjunto de estados alcançáveis.
+
+| De ↓ | Para permitido |
+| --- | --- |
+| `RASCUNHO` | `PENDENTE`, `CANCELADO` |
+| `PENDENTE` | `APROVADO`, `REJEITADO`, `CORRECAO_SOLICITADA`, `CANCELADO` |
+| `APROVADO` | `ATIVO`, `CANCELADO` |
+| `CORRECAO_SOLICITADA` | `PENDENTE`, `CANCELADO` |
+| `ATIVO` | `ENCERRADO`, `CANCELADO` |
+| `REJEITADO` | ∅ (terminal) |
+| `ENCERRADO` | ∅ (terminal) |
+| `CANCELADO` | ∅ (terminal) |
+
+## Comportamento em transição inválida
+
+O endpoint `POST /api/processos-estagio/{id}/alterar_status/` é o único ponto de entrada para mudar `status`. Antes de persistir, a view valida o destino pretendido com `pode_transicionar(processo.status, novo_status)` (na prática, via `transicoes_validas(processo.status)` em `views.py`). Se a transição não estiver no mapa, a resposta é **HTTP 400 Bad Request** com um payload que inclui as alternativas válidas — assim o cliente sabe o que pode fazer a partir do estado atual.
+
+A ordem de validação na view é importante e está documentada no próprio fluxo de `alterar_status`:
+
+1. Campo `status` foi enviado no body? Senão, 400.
+2. Transição existe em `TRANSICOES`? Senão, 400 com `transicoes_validas`.
+3. O usuário autenticado tem papel autorizado a disparar essa transição? Senão, 403.
+4. O serializer `AlterarStatusSerializer` consegue validar regras de negócio adicionais (por exemplo, justificativa obrigatória em `REJEITADO` — RN11)? Senão, 400.
+5. Persistir e retornar o processo completo via `ProcessoEstagioSerializer`.
+
+Essa ordem garante que o cliente recebe sempre o erro mais informativo possível: validação estrutural antes da semântica, semântica antes da autorização não-é, e validações de domínio por último.
+
+Exemplo, tentando reativar um processo já rejeitado (`REJEITADO → ATIVO`):
+
+```json
+{
+  "status": "Transição inválida: REJEITADO → ATIVO.",
+  "estado_atual": "REJEITADO",
+  "transicoes_validas": []
+}
+```
+
+Para um caso não-terminal, como tentar `PENDENTE → ATIVO` (faltando passar por `APROVADO`):
+
+```json
+{
+  "status": "Transição inválida: PENDENTE → ATIVO.",
+  "estado_atual": "PENDENTE",
+  "transicoes_validas": ["APROVADO", "CANCELADO", "CORRECAO_SOLICITADA", "REJEITADO"]
+}
+```
+
+O array `transicoes_validas` vem ordenado alfabeticamente para resposta determinística.
+
+## Permissões por papel ao alterar status
+
+A validação da máquina de estados garante que a transição **existe** no domínio. Em seguida, `ProcessoEstagioViewSet.alterar_status` aplica uma camada extra: quem pode disparar cada transição. Essa separação é deliberada — o mapa `TRANSICOES` codifica o que é fisicamente possível no fluxo de negócio; as permissões codificam quem está autorizado a operar essa máquina em cada papel.
+
+| Papel | Transições permitidas |
+| --- | --- |
+| Aluno (no próprio processo) | `RASCUNHO → PENDENTE`; qualquer estado vivo → `CANCELADO` |
+| Coordenador (em processos de alunos dos cursos sob sua coordenação) | `PENDENTE → {APROVADO, REJEITADO, CORRECAO_SOLICITADA}`; `APROVADO → ATIVO`; `ATIVO → ENCERRADO` |
+| Admin (`is_staff` ou `is_superuser`) | Qualquer transição dentro do mapa `TRANSICOES` |
+| Supervisor de empresa | Nenhuma ação por enquanto (fora do escopo desta entrega) |
+
+Violações de propriedade (aluno tentando alterar processo alheio, coordenador atuando em curso fora da sua coordenação) retornam **HTTP 403 Forbidden** com `{"detail": "..."}`. Violações da máquina retornam **HTTP 400**, conforme a seção anterior.
+
+Note que o coordenador **não pode** cancelar diretamente um processo: cancelamento por aluno cobre o caso "desisti", e cancelamento por admin cobre o caso "intervenção institucional". Isso evita que um coordenador encerre forçadamente um processo por engano, situação para a qual a transição correta é `ATIVO → ENCERRADO`.
+
+## API pública do módulo
+
+Resumo do que `state_machine.py` exporta para o resto do sistema:
+
+- **Constantes (str):** `RASCUNHO`, `PENDENTE`, `APROVADO`, `REJEITADO`, `CORRECAO_SOLICITADA`, `ATIVO`, `ENCERRADO`, `CANCELADO`.
+- **Conjuntos imutáveis:** `ESTADOS_TERMINAIS` (`REJEITADO`, `ENCERRADO`, `CANCELADO`), `ESTADOS_VIVOS` (`RASCUNHO`, `PENDENTE`, `APROVADO`, `CORRECAO_SOLICITADA`, `ATIVO`).
+- **Dict de transições:** `TRANSICOES: dict[str, set[str]]`.
+- **Funções utilitárias:**
+  - `transicoes_validas(estado_atual: str) -> set[str]`
+  - `pode_transicionar(de: str, para: str) -> bool`
+  - `eh_terminal(estado: str) -> bool`
+
+## Snippet do código
+
+```python
+# djangotutorial/app/state_machine.py
+TRANSICOES: dict[str, set[str]] = {
+    RASCUNHO:            {PENDENTE, CANCELADO},
+    PENDENTE:            {APROVADO, REJEITADO, CORRECAO_SOLICITADA, CANCELADO},
+    APROVADO:            {ATIVO, CANCELADO},
+    CORRECAO_SOLICITADA: {PENDENTE, CANCELADO},
+    ATIVO:               {ENCERRADO, CANCELADO},
+    REJEITADO:           set(),
+    ENCERRADO:           set(),
+    CANCELADO:           set(),
+}
+
+ESTADOS_TERMINAIS = frozenset({REJEITADO, ENCERRADO, CANCELADO})
+ESTADOS_VIVOS     = frozenset({RASCUNHO, PENDENTE, APROVADO, CORRECAO_SOLICITADA, ATIVO})
+
+
+def transicoes_validas(estado_atual: str) -> set[str]:
+    """Retorna o conjunto de estados que podem ser alcançados a partir de `estado_atual`."""
+    return TRANSICOES.get(estado_atual, set())
+
+
+def pode_transicionar(de: str, para: str) -> bool:
+    """True se a transição `de` → `para` é válida no fluxo do ProcessoEstagio."""
+    return para in transicoes_validas(de)
+
+
+def eh_terminal(estado: str) -> bool:
+    """True se `estado` é terminal (REJEITADO, ENCERRADO, CANCELADO)."""
+    return estado in ESTADOS_TERMINAIS
+```
+
+## Testes que provam
+
+A classe `StateMachineUnitTest` em `djangotutorial/app/tests.py` cobre o módulo com **4 testes unitários puros** — não tocam o banco, não usam `Client` do Django, não criam nenhum modelo. Eles validam, em isolamento:
+
+- Que `TRANSICOES` declara exatamente os estados de saída esperados para cada estado vivo.
+- Que `transicoes_validas` retorna conjunto vazio para os três terminais (`REJEITADO`, `ENCERRADO`, `CANCELADO`).
+- Que `pode_transicionar` aceita as transições do mapa e rejeita qualquer combinação fora dele.
+- Que `eh_terminal` reconhece corretamente o conjunto `ESTADOS_TERMINAIS` e nega para qualquer estado vivo.
+
+Esses testes são a primeira linha de defesa contra regressão silenciosa: se alguém alterar `TRANSICOES` sem atualizar a documentação ou as views, a suíte quebra antes do código chegar ao servidor.
+
+Complementarmente, testes de integração em `ProcessoEstagioApiTest` exercitam a view `alterar_status` ponta a ponta — autenticação por token, validação de permissão por papel, persistência via ORM e formato da resposta — para garantir que o módulo continua se comportando da mesma forma quando consumido por dentro do stack Django/DRF.
+
+## Autor(es)
+
+| Data | Versão | Descrição | Autor(es) |
+| -- | -- | -- | -- |
+| 28/05/2026 | 1.0 | Criação do documento | João Gabriel Teodósio |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,14 @@ nav:
       - Git Issues: Construcao/git_issues.md
       - GitHub Projects: Construcao/github_projects.md
       - CodeSpace: Construcao/codespace.md
+      - API:
+          - Visão Geral: Construcao/api/index.md
+          - Autenticação: Construcao/api/autenticacao.md
+          - Endpoints: Construcao/api/endpoints.md
+          - Regras de Negócio: Construcao/api/regras-negocio.md
+          - Máquina de Estados: Construcao/api/state-machine.md
+          - Exemplos de Uso: Construcao/api/exemplos.md
+          - Códigos de Erro: Construcao/api/erros.md
   - Transição:
       - Index: Transicao/index.md
 


### PR DESCRIPTION
## Contexto

Fecha #48. Adiciona a subseção **API** sob **Construção** na documentação MkDocs do projeto, cobrindo a API construída na PR #47 (issue #46 — ProcessoEstagio core).

> **Stacked PR**: esta PR aponta para `feat/processo-estagio` (a branch da PR #47), não direto pra main. Quando #47 mergear, o GitHub atualiza automaticamente o target desta PR para `main`.

## O que entra

7 documentos novos em `docs/Construcao/api/` (~2136 linhas):

| Documento | Conteúdo | Linhas |
|---|---|---|
| `index.md` | Visão geral, stack, arquitetura em camadas, padrões aplicados (MVT, DTO, State Machine, RBAC), links Swagger/Redoc | 157 |
| `autenticacao.md` | Token Auth, 3 tipos de usuário, payloads de register por tipo, exemplos curl | 274 |
| `endpoints.md` | Tabela mestre + por recurso, com foco em `/api/processos-estagio/` | 336 |
| `regras-negocio.md` | Rastreabilidade RN → linha de código → teste → HTTP. Cobre RN01/03/05/09/11 + Lei 11.788 + data | 317 |
| `state-machine.md` | Diagrama PlantUML, tabela De→Para, comportamento em transição inválida | 199 |
| `exemplos.md` | Walkthrough mão-na-massa em curl: happy path, 9 cenários de erro, isolamento por papel, Swagger UI, httpie | 644 |
| `erros.md` | Códigos HTTP × significado, 4 formatos de payload, mensagens padronizadas por RN | 209 |

Plus `mkdocs.yml` atualizado registrando a subseção:

```yaml
- Construção:
    - ... (entradas existentes)
    - API:
        - Visão Geral: Construcao/api/index.md
        - Autenticação: Construcao/api/autenticacao.md
        - Endpoints: Construcao/api/endpoints.md
        - Regras de Negócio: Construcao/api/regras-negocio.md
        - Máquina de Estados: Construcao/api/state-machine.md
        - Exemplos de Uso: Construcao/api/exemplos.md
        - Códigos de Erro: Construcao/api/erros.md
```

## Princípios respeitados

- **Linguagem pt-BR** em todo lugar (consistente com `docs/Elaboracao/`).
- **Apenas o implementado** é documentado. Funcionalidades das Pessoas 1/2/3/5 ainda não entregues estão marcadas como "fora do escopo desta entrega" nos lugares relevantes.
- **Estilo** alinhado a `docs/Elaboracao/` (headers, tabelas, code fences, PlantUML).
- **Sem emojis**. Caracteres unicode `✓ ⚠ ✗ ∅` usados para status.
- **Tabela "Autor(es)"** em todos os 7 documentos.

## Destaque acadêmico

O documento `regras-negocio.md` faz **rastreabilidade explícita** entre:

- Regra (RN do `docs/Elaboracao/Requisitos/Requisitos-Gerais.md` ou da Lei 11.788/08)
- Onde está validada no código (path do arquivo + função)
- Teste automatizado que prova o comportamento (nome + arquivo)
- HTTP status retornado

Isso é a evidência material de que cada regra do documento de requisitos virou código testado e auditável.

## Processo de criação

Fluxo executado com agentes especializados em paralelo:

1. **Grooming + issue** — issue #48 criada com escopo claro
2. **4 agentes writers em paralelo** (~3.5 min wall-clock):
   - Agente A (Foundation): `index.md` + `endpoints.md`
   - Agente B (Conceptual): `autenticacao.md` + `state-machine.md`
   - Agente C (Reference): `regras-negocio.md` + `erros.md`
   - Agente D (Walkthrough): `exemplos.md`
3. **Agente E (Reviewer, sequencial)** — leu os 7 docs, checou consistência de nomes/estilo/links, corrigiu drift (3 anchors quebrados, 2 links pra arquivo inexistente), atualizou `mkdocs.yml`, rodou `mkdocs build --strict`.
4. **Review humana final** — verificação de sanity (file count, build, git status).

## Validação

```bash
.venv/bin/mkdocs build --strict
# Documentation built in 1.30 seconds — sem warnings
```

Verificação local:

```bash
uv run mkdocs serve
# Navegar para http://localhost:8000/Construcao/api/
```

## Como revisar este PR

1. Abrir os 7 docs novos em `docs/Construcao/api/` — ler cada um em sequência (`index` → `autenticacao` → `endpoints` → `regras-negocio` → `state-machine` → `exemplos` → `erros`).
2. Rodar `mkdocs serve` localmente e navegar pela subseção pelo menu.
3. Verificar que o PlantUML do `state-machine.md` renderiza corretamente (precisa de conexão com `plantuml.com` configurado em `mkdocs.yml`).
4. Verificar que links internos entre os docs funcionam.

## Issues relacionadas

- #48 (esta — documentação)
- #46 (ProcessoEstagio core — implementação)
- PR #47 (implementação, ainda OPEN)